### PR TITLE
Small fix for bug with back navigation after new/edit trip save

### DIFF
--- a/app/src/main/java/co/smartreceipts/android/activities/NavigationHandler.java
+++ b/app/src/main/java/co/smartreceipts/android/activities/NavigationHandler.java
@@ -79,6 +79,11 @@ public class NavigationHandler {
         }
     }
 
+    public void navigateToReportInfoFragmentWithoutBackStack(@NonNull Trip trip) {
+        mFragmentManager.popBackStackImmediate();
+        navigateToReportInfoFragment(trip);
+    }
+
     public void navigateToCreateNewReceiptFragment(@NonNull Trip trip, @Nullable File file, @Nullable OcrResponse ocrResponse) {
         if (mIsDualPane) {
             replaceFragmentWithAnimation(mFragmentProvider.newCreateReceiptFragment(trip, file, ocrResponse), R.id.content_details, R.anim.enter_from_bottom, DO_NOT_ANIM);
@@ -241,7 +246,10 @@ public class NavigationHandler {
             if (enterAnimId >= 0 && exitAnimId >= 0) {
                 transaction.setCustomAnimations(enterAnimId, exitAnimId);
             }
-            transaction.replace(layoutResId, fragment, tag).addToBackStack(tag).setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN).commit();
+            transaction.replace(layoutResId, fragment, tag)
+                    .addToBackStack(tag)
+                    .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
+                    .commit();
         }
     }
 }

--- a/app/src/main/java/co/smartreceipts/android/trips/editor/TripCreateEditFragment.java
+++ b/app/src/main/java/co/smartreceipts/android/trips/editor/TripCreateEditFragment.java
@@ -296,7 +296,7 @@ public class TripCreateEditFragment extends WBFragment implements View.OnFocusCh
             Trip updatedTrip = presenter.saveTrip(name, startDateBox.date, endDateBox.date,
                     currencyCode, comment, costCenter);
             // open created/edited trip info
-            navigationHandler.navigateToReportInfoFragment(updatedTrip);
+            navigationHandler.navigateToReportInfoFragmentWithoutBackStack(updatedTrip);
         }
     }
 


### PR DESCRIPTION
Little fix and long text :)

When we tried to save new/edited trip with `TripCreateEditFragment`, we had back stack with such transactions: 

- replace(`TripFragment`, `TripCreateEditFragment`) == remove(`TripFragment`), add(`TripCreateEditFragment`)
- replace(`TripCreateEditFragment`, `ReportInfoFragment`) == remove(`TripCreateEditFragment`), add(`ReportInfoFragment`)

So, when we click back button, `onBackPressed()` is called -> `popBackStackImmediate()` -> calling last transaction reverced -> remove(`ReportInfoFragment`), add(`TripCreateEditFragment`).

At first glance behavior that we need for `TripCreateEditFragment` looks similar to `ReceiptCreateEditFragment`, but when `ReceiptCreateEditFragment` is opened we have such back stack:
- replace(`TripFragment`, `ReportInfoFragment`)
- replace(`ReportInfoFragment`, `ReceiptCreateEditFragment`)

And `ReportInfoFragment` is that one which will be added when the back button will be pressed.

Thus, with `TripFragment`->`TripCreateEditFragment`->`ReportInfoFragment `chain we need to "forget" about `TripCreateEditFragment`.

I solved it by one extra calling of `popBackStackImmediate()`, so when we click save button on `TripCreateEditFragment`, last transaction from back stack is popped and then `ReportInfoFragment` is opened. Back stack works like this:
- replace(`TripFragment`, `TripCreateEditFragment`)
- `popBackStackImmediate() `
- replace(`TripFragment`, `ReportInfoFragment`).

Now `onBackPressed()` does correct things and `TripCreateEditFragment` is "forgotten".

This solution makes barely visible blink, but it's much less tricky than other possible solutions.