### PR TITLE
Fix for Rx undeliverable exception 

### DIFF
--- a/app/src/main/java/co/smartreceipts/android/purchases/PurchaseManager.java
+++ b/app/src/main/java/co/smartreceipts/android/purchases/PurchaseManager.java
@@ -19,7 +19,6 @@ import com.google.gson.Gson;
 
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.reactivestreams.Subscriber;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -446,11 +445,15 @@ public class PurchaseManager {
                             emitter.onComplete();
                         } else {
                             Logger.error(PurchaseManager.this, "Failed to get available skus for purchase");
-                            emitter.onError(new Exception("Failed to get available skus for purchase"));
+                            if (!emitter.isDisposed()) {
+                                emitter.onError(new Exception("Failed to get available skus for purchase"));
+                            }
                         }
                     } catch (RemoteException e) {
                         Logger.error(PurchaseManager.this, "Failed to get available skus for purchase", e);
-                        emitter.onError(e);
+                        if (!emitter.isDisposed()) {
+                            emitter.onError(e);
+                        }
                     }
                 }));
     }


### PR DESCRIPTION
I've found crush caused by Rx undeliverable exception when the user flow is: menu -> Automatic Scans (OCR) -> back (without internet connection).

Looks like `emitter` is already disposed but we try to call `emitter.onError` and Rx throws that undeliverable exception.
Thus, I've wrapped this call with an additional check and it doesn't crush more.