### PR TITLE
Added UseNativeAds(false) to FeatureFlags

### DIFF
--- a/app/src/free/java/co/smartreceipts/android/di/SmartReceiptsActivityAdModule.java
+++ b/app/src/free/java/co/smartreceipts/android/di/SmartReceiptsActivityAdModule.java
@@ -6,19 +6,18 @@ import co.smartreceipts.android.ad.AdPresenter;
 import co.smartreceipts.android.ad.impl.ClassicBannerAdPresenter;
 import co.smartreceipts.android.ad.impl.NativeBannerAdPresenter;
 import co.smartreceipts.android.di.scopes.ActivityScope;
+import co.smartreceipts.android.utils.FeatureFlags;
 import dagger.Module;
 import dagger.Provides;
 
 @Module
 public class SmartReceiptsActivityAdModule {
 
-    private final static boolean USE_CLASSIC_ADS = true;
-
     @Provides
     @ActivityScope
     public static AdPresenter provideAdPresenter(Provider<ClassicBannerAdPresenter> classicBannerAdPresenterProvider,
                                                  Provider<NativeBannerAdPresenter> nativeBannerAdPresenterProvider) {
-        return USE_CLASSIC_ADS ? classicBannerAdPresenterProvider.get() : nativeBannerAdPresenterProvider.get();
+        return FeatureFlags.UseNativeAds.isEnabled() ? nativeBannerAdPresenterProvider.get() : classicBannerAdPresenterProvider.get();
     }
 
 }

--- a/app/src/free/res/layout/activity_main_onepane.xml
+++ b/app/src/free/res/layout/activity_main_onepane.xml
@@ -6,7 +6,6 @@
     tools:context=".activities.SmartReceiptsActivity" >
 
     <FrameLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/content_list"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/java/co/smartreceipts/android/imports/ActivityFileResultImporter.java
+++ b/app/src/main/java/co/smartreceipts/android/imports/ActivityFileResultImporter.java
@@ -104,8 +104,6 @@ public class ActivityFileResultImporter {
                         headlessFragment.importSubject.onComplete();
                     }
                 });
-
-        // TODO: 12.04.2017 !!! check dispose(). not sure if it works correctly
     }
 
     public Observable<ActivityFileResultImporterResponse> getResultStream() {

--- a/app/src/main/java/co/smartreceipts/android/utils/FeatureFlags.java
+++ b/app/src/main/java/co/smartreceipts/android/utils/FeatureFlags.java
@@ -2,7 +2,7 @@ package co.smartreceipts.android.utils;
 
 public enum FeatureFlags implements Feature {
 
-    Ocr(true), OrganizationSyncing(false), CompatPdfRendering(true);
+    Ocr(true), OrganizationSyncing(false), CompatPdfRendering(true), UseNativeAds(false);
 
     private final boolean isEnabled;
 


### PR DESCRIPTION
I've added `UseNativeAds` to `FeatureFlags`.

As about lint error relating to `ad_layout`, at first I didn't fully understand the problem, but the thing is now we have no such errors because all code that somehow uses ads now is located in the free flavor module (I mean all `AdPresenter` implementations except `EmptyBannerAdPresenter` which is in the plus flavor).