### PR TITLE
Injectable ActivityFileResultImporter

### DIFF
--- a/app/src/main/java/co/smartreceipts/android/fragments/ReceiptImageFragment.java
+++ b/app/src/main/java/co/smartreceipts/android/fragments/ReceiptImageFragment.java
@@ -72,6 +72,8 @@ public class ReceiptImageFragment extends WBFragment {
     NavigationHandler navigationHandler;
     @Inject
     FragmentStateCache fragmentStateCache;
+    @Inject
+    ActivityFileResultImporter activityFileResultImporter;
 
 
     private PinchToZoomImageView imageView;
@@ -80,7 +82,6 @@ public class ReceiptImageFragment extends WBFragment {
     private Toolbar toolbar;
 
     private Receipt receipt;
-    private ActivityFileResultImporter activityFileResultImporter;
     private ImageUpdatedListener imageUpdatedListener;
     private CompositeDisposable compositeDisposable;
     private boolean isRotateOngoing;
@@ -106,8 +107,6 @@ public class ReceiptImageFragment extends WBFragment {
             imageUri = savedInstanceState.getParcelable(KEY_OUT_URI);
         }
         isRotateOngoing = false;
-        activityFileResultImporter = new ActivityFileResultImporter(getActivity(), getFragmentManager(), receipt.getTrip(),
-                persistenceManager, analytics, ocrManager);
         imageUpdatedListener = new ImageUpdatedListener();
         setHasOptionsMenu(true);
     }
@@ -174,7 +173,7 @@ public class ReceiptImageFragment extends WBFragment {
         final Uri cachedImageSaveLocation = imageUri;
         imageUri = null;
 
-        activityFileResultImporter.onActivityResult(requestCode, resultCode, data, cachedImageSaveLocation);
+        activityFileResultImporter.onActivityResult(requestCode, resultCode, data, cachedImageSaveLocation, receipt.getTrip());
     }
 
     @Override

--- a/app/src/main/java/co/smartreceipts/android/identity/widget/login/LoginPresenter.java
+++ b/app/src/main/java/co/smartreceipts/android/identity/widget/login/LoginPresenter.java
@@ -2,11 +2,8 @@ package co.smartreceipts.android.identity.widget.login;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import com.google.common.base.Preconditions;
-
-import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
@@ -45,6 +42,7 @@ public class LoginPresenter extends BasePresenter<LoginView, LoginInteractor> {
                                 view.getPasswordTextChanges(),
                                 (BiFunction<CharSequence, CharSequence, UserCredentialsPayload>) SmartReceiptsUserLogin::new)
                         .flatMap(userCredentialsPayload -> view.getLoginButtonClicks().map(ignored -> userCredentialsPayload)),
+
                         Observable.combineLatest(
                                 view.getEmailTextChanges(),
                                 view.getPasswordTextChanges(),

--- a/app/src/main/java/co/smartreceipts/android/imports/FileImportProcessorFactory.java
+++ b/app/src/main/java/co/smartreceipts/android/imports/FileImportProcessorFactory.java
@@ -3,40 +3,35 @@ package co.smartreceipts.android.imports;
 import android.content.Context;
 import android.support.annotation.NonNull;
 
-import com.google.common.base.Preconditions;
+import javax.inject.Inject;
 
 import co.smartreceipts.android.model.Trip;
-import co.smartreceipts.android.persistence.PersistenceManager;
 import co.smartreceipts.android.settings.UserPreferenceManager;
 import wb.android.storage.StorageManager;
 
 public class FileImportProcessorFactory {
 
     private final Context context;
-    private final Trip trip;
-    private final StorageManager storageManager;
     private final UserPreferenceManager preferenceManager;
+    private final StorageManager storageManager;
 
-    public FileImportProcessorFactory(@NonNull Context context, @NonNull Trip trip, @NonNull PersistenceManager persistenceManager) {
-        this(context, trip, persistenceManager.getStorageManager(), persistenceManager.getPreferenceManager());
-    }
-
-    public FileImportProcessorFactory(@NonNull Context context, @NonNull Trip trip, @NonNull StorageManager storageManager,
-                                      @NonNull UserPreferenceManager preferenceManager) {
-        this.context = Preconditions.checkNotNull(context.getApplicationContext());
-        this.trip = Preconditions.checkNotNull(trip);
-        this.storageManager = Preconditions.checkNotNull(storageManager);
-        this.preferenceManager = Preconditions.checkNotNull(preferenceManager);
+    @Inject
+    FileImportProcessorFactory(Context context, UserPreferenceManager userPreferenceManager, StorageManager storageManager) {
+        this.context = context;
+        this.preferenceManager = userPreferenceManager;
+        this.storageManager = storageManager;
     }
 
     @NonNull
-    public FileImportProcessor get(int requestCode) {
+    public FileImportProcessor get(int requestCode, @NonNull Trip trip) {
         if (RequestCodes.PHOTO_REQUESTS.contains(requestCode)) {
             return new ImageImportProcessor(trip, storageManager, preferenceManager, context);
-        } else if (RequestCodes.PDF_REQUESTS.contains(requestCode)) {
-            return new GenericFileImportProcessor(trip, storageManager, context);
-        } else {
-            return new AutoFailImportProcessor();
         }
+
+        if (RequestCodes.PDF_REQUESTS.contains(requestCode)) {
+            return new GenericFileImportProcessor(trip, storageManager, context);
+        }
+
+        return new AutoFailImportProcessor();
     }
 }

--- a/app/src/main/java/co/smartreceipts/android/receipts/ReceiptsListFragment.java
+++ b/app/src/main/java/co/smartreceipts/android/receipts/ReceiptsListFragment.java
@@ -88,9 +88,10 @@ public class ReceiptsListFragment extends ReceiptsFragment implements ReceiptTab
     NavigationHandler navigationHandler;
     @Inject
     FragmentStateCache fragmentStateCache;
+    @Inject
+    ActivityFileResultImporter activityFileResultImporter;
 
     private ReceiptCardAdapter adapter;
-    private ActivityFileResultImporter activityFileResultImporter;
     private Receipt highlightedReceipt;
     private Uri imageUri;
     private ProgressBar loadingProgress;
@@ -192,8 +193,6 @@ public class ReceiptsListFragment extends ReceiptsFragment implements ReceiptTab
         Logger.debug(this, "onActivityCreated");
         trip = ((ReportInfoFragment) getParentFragment()).getTrip();
         Preconditions.checkNotNull(trip, "A valid trip is required");
-        activityFileResultImporter = new ActivityFileResultImporter(getActivity(), getFragmentManager(),
-                trip, persistenceManager, analytics, ocrManager);
         setListAdapter(adapter); // Set this here to ensure this has been laid out already
     }
 
@@ -279,7 +278,7 @@ public class ReceiptsListFragment extends ReceiptsFragment implements ReceiptTab
         imageUri = null;
 
         updatingDataProgress.setVisibility(View.VISIBLE);
-        activityFileResultImporter.onActivityResult(requestCode, resultCode, data, cachedImageSaveLocation);
+        activityFileResultImporter.onActivityResult(requestCode, resultCode, data, cachedImageSaveLocation, trip);
 
         if (resultCode != Activity.RESULT_OK) {
             updatingDataProgress.setVisibility(View.GONE);

--- a/app/src/test/java/co/smartreceipts/android/imports/FileImportProcessorFactoryTest.java
+++ b/app/src/test/java/co/smartreceipts/android/imports/FileImportProcessorFactoryTest.java
@@ -32,25 +32,25 @@ public class FileImportProcessorFactoryTest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        this.factory = new FileImportProcessorFactory(RuntimeEnvironment.application, trip, storageManager, preferenceManager);
+        this.factory = new FileImportProcessorFactory(RuntimeEnvironment.application, preferenceManager, storageManager);
     }
 
     @Test
     public void get() {
         // Image Imports
-        assertTrue(this.factory.get(RequestCodes.NATIVE_ADD_PHOTO_CAMERA_REQUEST) instanceof ImageImportProcessor);
-        assertTrue(this.factory.get(RequestCodes.NATIVE_NEW_RECEIPT_CAMERA_REQUEST) instanceof ImageImportProcessor);
-        assertTrue(this.factory.get(RequestCodes.NATIVE_RETAKE_PHOTO_CAMERA_REQUEST) instanceof ImageImportProcessor);
-        assertTrue(this.factory.get(RequestCodes.IMPORT_GALLERY_IMAGE) instanceof ImageImportProcessor);
+        assertTrue(this.factory.get(RequestCodes.NATIVE_ADD_PHOTO_CAMERA_REQUEST, trip) instanceof ImageImportProcessor);
+        assertTrue(this.factory.get(RequestCodes.NATIVE_NEW_RECEIPT_CAMERA_REQUEST, trip) instanceof ImageImportProcessor);
+        assertTrue(this.factory.get(RequestCodes.NATIVE_RETAKE_PHOTO_CAMERA_REQUEST, trip) instanceof ImageImportProcessor);
+        assertTrue(this.factory.get(RequestCodes.IMPORT_GALLERY_IMAGE, trip) instanceof ImageImportProcessor);
 
         // PDF Imports
-        assertTrue(this.factory.get(RequestCodes.IMPORT_GALLERY_PDF) instanceof GenericFileImportProcessor);
+        assertTrue(this.factory.get(RequestCodes.IMPORT_GALLERY_PDF, trip) instanceof GenericFileImportProcessor);
 
         // Rest are auto fail
-        assertTrue(this.factory.get(-1) instanceof AutoFailImportProcessor);
-        assertTrue(this.factory.get(0) instanceof AutoFailImportProcessor);
-        assertTrue(this.factory.get(Integer.MAX_VALUE) instanceof AutoFailImportProcessor);
-        assertTrue(this.factory.get(Integer.MIN_VALUE) instanceof AutoFailImportProcessor);
+        assertTrue(this.factory.get(-1, trip) instanceof AutoFailImportProcessor);
+        assertTrue(this.factory.get(0, trip) instanceof AutoFailImportProcessor);
+        assertTrue(this.factory.get(Integer.MAX_VALUE, trip) instanceof AutoFailImportProcessor);
+        assertTrue(this.factory.get(Integer.MIN_VALUE, trip) instanceof AutoFailImportProcessor);
     }
 
 }


### PR DESCRIPTION
Now `ActivityFileResultImporter` is injectable, has `@ApplicationScope` and doesn't use headless fragment.
`FileImportProcessorFactory` now is also injectable (without scope).

Generally, there are no serious changes, just some kind of refactoring :)