### PR TITLE
Added new Plus option "Omit Default PDF Table"

### DIFF
--- a/app/src/main/java/co/smartreceipts/android/fragments/GenerateReportFragment.java
+++ b/app/src/main/java/co/smartreceipts/android/fragments/GenerateReportFragment.java
@@ -23,6 +23,7 @@ import co.smartreceipts.android.analytics.Analytics;
 import co.smartreceipts.android.analytics.events.Events;
 import co.smartreceipts.android.model.Trip;
 import co.smartreceipts.android.persistence.PersistenceManager;
+import co.smartreceipts.android.purchases.wallet.PurchaseWallet;
 import co.smartreceipts.android.utils.log.Logger;
 import co.smartreceipts.android.widget.tooltip.report.generate.GenerateInfoTooltipManager;
 import co.smartreceipts.android.workers.EmailAssistant;
@@ -41,6 +42,8 @@ public class GenerateReportFragment extends WBFragment implements View.OnClickLi
     NavigationHandler navigationHandler;
     @Inject
     GenerateInfoTooltipManager generateInfoTooltipManager;
+    @Inject
+    PurchaseWallet purchaseWallet;
 
     private CheckBox pdfFullCheckbox;
     private CheckBox pdfImagesCheckbox;
@@ -155,7 +158,8 @@ public class GenerateReportFragment extends WBFragment implements View.OnClickLi
             options.add(EmailAssistant.EmailOptions.ZIP_IMAGES_STAMPED);
         }
 
-        final EmailAssistant emailAssistant = new EmailAssistant(navigationHandler, getActivity(), flex, persistenceManager, trip);
+        final EmailAssistant emailAssistant = new EmailAssistant(navigationHandler, getActivity(),
+                flex, persistenceManager, trip, purchaseWallet);
         emailAssistant.emailTrip(options);
     }
 }

--- a/app/src/main/java/co/smartreceipts/android/settings/catalog/UserPreference.java
+++ b/app/src/main/java/co/smartreceipts/android/settings/catalog/UserPreference.java
@@ -76,6 +76,7 @@ public final class UserPreference<T> {
         public static final UserPreference<String> PdfFooterString = new UserPreference<>(String.class, R.string.pref_pro_pdf_footer_key, R.string.pref_pro_pdf_footer_defaultValue);
         public static final UserPreference<Boolean> SeparateByCategoryInReports = new UserPreference<>(Boolean.class, R.string.pref_pro_separate_by_category_key, R.bool.pref_pro_separate_by_category_defaultValue);
         public static final UserPreference<Boolean> CategoricalSummationInReports = new UserPreference<>(Boolean.class, R.string.pref_pro_categorical_summation_key, R.bool.pref_pro_categorical_summation_defaultValue);
+        public static final UserPreference<Boolean> OmitDefaultTableInReports = new UserPreference<>(Boolean.class, R.string.pref_pro_omit_default_table_key, R.bool.pref_pro_omit_default_table_defaultValue);
     }
 
     public static final class Misc {

--- a/app/src/main/java/co/smartreceipts/android/settings/widget/SettingsActivity.java
+++ b/app/src/main/java/co/smartreceipts/android/settings/widget/SettingsActivity.java
@@ -341,6 +341,10 @@ public class SettingsActivity extends AppCompatPreferenceActivity implements OnP
         final PlusCheckBoxPreference categoricalSummationPreference = (PlusCheckBoxPreference) universal.findPreference(R.string.pref_pro_categorical_summation_key);
         categoricalSummationPreference.setAppearsEnabled(hasProSubscription);
         categoricalSummationPreference.setOnPreferenceClickListener(this);
+
+        final PlusCheckBoxPreference omitDefaultTablePreference = (PlusCheckBoxPreference) universal.findPreference(R.string.pref_pro_omit_default_table_key);
+        omitDefaultTablePreference.setAppearsEnabled(hasProSubscription);
+        omitDefaultTablePreference.setOnPreferenceClickListener(this);
     }
 
     public void configurePreferencesHelp(UniversalPreferences universal) {
@@ -391,7 +395,8 @@ public class SettingsActivity extends AppCompatPreferenceActivity implements OnP
             return true;
         } else if (key.equals(getString(R.string.pref_pro_pdf_footer_key)) ||
                 key.equals(getString(R.string.pref_pro_separate_by_category_key)) ||
-                key.equals(getString(R.string.pref_pro_categorical_summation_key))) {
+                key.equals(getString(R.string.pref_pro_categorical_summation_key)) ||
+                key.equals(getString(R.string.pref_pro_omit_default_table_key))) {
             tryToMakePurchaseIfNeed();
             return true;
         } else if (key.equals(getString(R.string.pref_about_privacy_policy_key))) {

--- a/app/src/main/java/co/smartreceipts/android/workers/EmailAssistant.java
+++ b/app/src/main/java/co/smartreceipts/android/workers/EmailAssistant.java
@@ -41,6 +41,7 @@ import co.smartreceipts.android.persistence.PersistenceManager;
 import co.smartreceipts.android.persistence.database.controllers.grouping.GroupingController;
 import co.smartreceipts.android.persistence.database.controllers.grouping.results.CategoryGroupingResult;
 import co.smartreceipts.android.persistence.database.controllers.grouping.results.SumCategoryGroupingResult;
+import co.smartreceipts.android.purchases.wallet.PurchaseWallet;
 import co.smartreceipts.android.settings.UserPreferenceManager;
 import co.smartreceipts.android.settings.catalog.UserPreference;
 import co.smartreceipts.android.utils.IntentUtils;
@@ -83,6 +84,7 @@ public class EmailAssistant {
     private final Flex flex;
     private final PersistenceManager persistenceManager;
     private final Trip trip;
+    private final PurchaseWallet purchaseWallet;
 
     public static final Intent getEmailDeveloperIntent() {
         Intent intent = new Intent(Intent.ACTION_SENDTO);
@@ -117,12 +119,14 @@ public class EmailAssistant {
         return intent;
     }
 
-    public EmailAssistant(NavigationHandler navigationHandler, Context context, Flex flex, PersistenceManager persistenceManager, Trip trip) {
+    public EmailAssistant(NavigationHandler navigationHandler, Context context, Flex flex,
+                          PersistenceManager persistenceManager, Trip trip, PurchaseWallet purchaseWallet) {
         this.navigationHandler = navigationHandler;
         this.context = context;
         this.flex = flex;
         this.persistenceManager = persistenceManager;
         this.trip = trip;
+        this.purchaseWallet = purchaseWallet;
     }
 
     public void emailTrip(@NonNull EnumSet<EmailOptions> options) {
@@ -282,7 +286,7 @@ public class EmailAssistant {
             if (mOptions.contains(EmailOptions.PDF_FULL)) {
                 final Report pdfFullReport = new PdfBoxFullPdfReport(context, mDB,
                         persistenceManager.getPreferenceManager(), persistenceManager.getStorageManager(),
-                        flex);
+                        flex, purchaseWallet);
                 try {
                     mFiles[EmailOptions.PDF_FULL.getIndex()] = pdfFullReport.generate(trip);
                 } catch (ReportGenerationException e) {

--- a/app/src/main/java/co/smartreceipts/android/workers/reports/pdf/PdfBoxFullPdfReport.java
+++ b/app/src/main/java/co/smartreceipts/android/workers/reports/pdf/PdfBoxFullPdfReport.java
@@ -17,6 +17,7 @@ import co.smartreceipts.android.persistence.DatabaseHelper;
 import co.smartreceipts.android.persistence.database.controllers.grouping.GroupingController;
 import co.smartreceipts.android.persistence.database.controllers.grouping.results.CategoryGroupingResult;
 import co.smartreceipts.android.persistence.database.controllers.grouping.results.SumCategoryGroupingResult;
+import co.smartreceipts.android.purchases.wallet.PurchaseWallet;
 import co.smartreceipts.android.settings.UserPreferenceManager;
 import co.smartreceipts.android.workers.reports.pdf.pdfbox.PdfBoxReportFile;
 import wb.android.flex.Flex;
@@ -25,12 +26,15 @@ import wb.android.storage.StorageManager;
 public class PdfBoxFullPdfReport extends PdfBoxAbstractReport {
 
     private final GroupingController groupingController;
+    private final PurchaseWallet purchaseWallet;
 
     public PdfBoxFullPdfReport(Context context, DatabaseHelper db,
                                UserPreferenceManager preferences,
-                               StorageManager storageManager, Flex flex) {
+                               StorageManager storageManager, Flex flex, PurchaseWallet purchaseWallet) {
         super(context, db, preferences, storageManager, flex);
         this.groupingController = new GroupingController(db, context, preferences);
+        this.purchaseWallet = purchaseWallet;
+
     }
 
     @Override
@@ -55,7 +59,7 @@ public class PdfBoxFullPdfReport extends PdfBoxAbstractReport {
 
         pdfBoxReportFile.addSection(pdfBoxReportFile.createReceiptsTableSection(trip,
                 receipts, columns, distances, distanceColumns, categories, categoryColumns,
-                groupingResults));
+                groupingResults, purchaseWallet));
         pdfBoxReportFile.addSection(pdfBoxReportFile.createReceiptsImagesSection(trip, receipts));
     }
 

--- a/app/src/main/java/co/smartreceipts/android/workers/reports/pdf/pdfbox/PdfBoxReportFile.java
+++ b/app/src/main/java/co/smartreceipts/android/workers/reports/pdf/pdfbox/PdfBoxReportFile.java
@@ -16,6 +16,7 @@ import co.smartreceipts.android.model.Receipt;
 import co.smartreceipts.android.model.Trip;
 import co.smartreceipts.android.persistence.database.controllers.grouping.results.CategoryGroupingResult;
 import co.smartreceipts.android.persistence.database.controllers.grouping.results.SumCategoryGroupingResult;
+import co.smartreceipts.android.purchases.wallet.PurchaseWallet;
 import co.smartreceipts.android.settings.UserPreferenceManager;
 import co.smartreceipts.android.utils.log.Logger;
 import co.smartreceipts.android.workers.reports.pdf.PdfReportFile;
@@ -71,11 +72,12 @@ public class PdfBoxReportFile implements PdfReportFile, PdfBoxSectionFactory {
             @NonNull List<Distance> distances, @NonNull List<Column<Distance>> distanceColumns,
             @NonNull List<SumCategoryGroupingResult> categpries,
             @NonNull List<Column<SumCategoryGroupingResult>> categoryColumns,
-            @NonNull List<CategoryGroupingResult> groupingResults) {
+            @NonNull List<CategoryGroupingResult> groupingResults,
+            @NonNull PurchaseWallet purchaseWallet) {
 
         return new PdfBoxReceiptsTablePdfSection(pdfBoxContext, trip, receipts, columns,
                 distances, distanceColumns, categpries, categoryColumns,
-                groupingResults);
+                groupingResults, purchaseWallet);
     }
 
 

--- a/app/src/main/java/co/smartreceipts/android/workers/reports/pdf/pdfbox/PdfBoxSectionFactory.java
+++ b/app/src/main/java/co/smartreceipts/android/workers/reports/pdf/pdfbox/PdfBoxSectionFactory.java
@@ -10,6 +10,7 @@ import co.smartreceipts.android.model.Receipt;
 import co.smartreceipts.android.model.Trip;
 import co.smartreceipts.android.persistence.database.controllers.grouping.results.CategoryGroupingResult;
 import co.smartreceipts.android.persistence.database.controllers.grouping.results.SumCategoryGroupingResult;
+import co.smartreceipts.android.purchases.wallet.PurchaseWallet;
 
 public interface PdfBoxSectionFactory {
 
@@ -22,7 +23,8 @@ public interface PdfBoxSectionFactory {
             @NonNull List<Column<Distance>> distanceColumns,
             @NonNull List<SumCategoryGroupingResult> categories,
             @NonNull List<Column<SumCategoryGroupingResult>> categoryColumns,
-            @NonNull List<CategoryGroupingResult> groupingResults);
+            @NonNull List<CategoryGroupingResult> groupingResults,
+            @NonNull PurchaseWallet purchaseWallet);
 
     @NonNull
     PdfBoxReceiptsImagesPdfSection createReceiptsImagesSection(@NonNull Trip trip,

--- a/app/src/main/res/values/preference_defaults.xml
+++ b/app/src/main/res/values/preference_defaults.xml
@@ -52,8 +52,9 @@
 
     <!-- ================= Preference Pro ================== -->
     <string name="pref_pro_pdf_footer_defaultValue">Report Generated using Smart Receipts for Android</string>
-    <bool name="pref_pro_separate_by_category_defaultValue">false</bool>
-    <bool name="pref_pro_categorical_summation_defaultValue">false</bool>
+    <bool name="pref_pro_separate_by_category_defaultValue">true</bool>
+    <bool name="pref_pro_categorical_summation_defaultValue">true</bool>
+    <bool name="pref_pro_omit_default_table_defaultValue">true</bool>
 
     <!-- =============== Preference Misc =================== -->
     <bool name="pref_no_category_auto_backup_wifi_only_defaultValue">true</bool>

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -162,6 +162,8 @@
     <string name="pref_pro_categorical_summation_title">Include Categorical Summation</string>
     <string name="pref_pro_categorical_summation_summaryOn">PDF/CSV reports include table with summation by category</string>
     <string name="pref_pro_categorical_summation_summaryOff">PDF/CSV reports don\'t include table with summation by category</string>
+    <string name="pref_pro_omit_default_table_key" translatable="false">OmitDefaultPDFTable</string>
+    <string name="pref_pro_omit_default_table_title">Omit Default PDF Table</string>
 
 
     <!-- ============== Preference Support ================= -->

--- a/app/src/main/res/xml/preference_legacy.xml
+++ b/app/src/main/res/xml/preference_legacy.xml
@@ -267,6 +267,10 @@
             android:summaryOff="@string/pref_pro_categorical_summation_summaryOff"
             android:summaryOn="@string/pref_pro_categorical_summation_summaryOn"
             android:title="@string/pref_pro_categorical_summation_title" />
+        <wb.android.preferences.PlusCheckBoxPreference
+            android:defaultValue="@bool/pref_pro_omit_default_table_defaultValue"
+            android:key="@string/pref_pro_omit_default_table_key"
+            android:title="@string/pref_pro_omit_default_table_title" />
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/main/res/xml/preferences_pro.xml
+++ b/app/src/main/res/xml/preferences_pro.xml
@@ -20,5 +20,9 @@
             android:summaryOff="@string/pref_pro_categorical_summation_summaryOff"
             android:summaryOn="@string/pref_pro_categorical_summation_summaryOn"
             android:title="@string/pref_pro_categorical_summation_title" />
+        <wb.android.preferences.PlusCheckBoxPreference
+            android:defaultValue="@bool/pref_pro_omit_default_table_defaultValue"
+            android:key="@string/pref_pro_omit_default_table_key"
+            android:title="@string/pref_pro_omit_default_table_title" />
     </PreferenceCategory>
 </PreferenceScreen>

--- a/app/src/test/java/co/smartreceipts/android/report/InteractivePdfBoxTest.java
+++ b/app/src/test/java/co/smartreceipts/android/report/InteractivePdfBoxTest.java
@@ -55,6 +55,8 @@ import co.smartreceipts.android.model.impl.columns.receipts.ReceiptPriceColumn;
 import co.smartreceipts.android.persistence.PersistenceManager;
 import co.smartreceipts.android.persistence.database.controllers.grouping.results.CategoryGroupingResult;
 import co.smartreceipts.android.persistence.database.controllers.grouping.results.SumCategoryGroupingResult;
+import co.smartreceipts.android.purchases.model.InAppPurchase;
+import co.smartreceipts.android.purchases.wallet.PurchaseWallet;
 import co.smartreceipts.android.settings.UserPreferenceManager;
 import co.smartreceipts.android.settings.catalog.UserPreference;
 import co.smartreceipts.android.sync.model.impl.DefaultSyncState;
@@ -93,6 +95,9 @@ public class InteractivePdfBoxTest {
     @Mock
     UserPreferenceManager userPreferenceManager;
 
+    @Mock
+    PurchaseWallet purchaseWallet;
+
     /**
      * Base method, to be overridden by subclasses. The subclass must annotate the method
      * with the JUnit <code>@Before</code> annotation, and initialize the mocks.
@@ -119,6 +124,7 @@ public class InteractivePdfBoxTest {
         when(userPreferenceManager.get(UserPreference.Distance.PrintDistanceTableInReports)).thenReturn(true);
         when(userPreferenceManager.get(UserPreference.Distance.PrintDistanceAsDailyReceiptInReports)).thenReturn(false);
         when(userPreferenceManager.get(UserPreference.PlusSubscription.PdfFooterString)).thenReturn("Report generated using Smart Receipts for Android");
+        when(purchaseWallet.hasActivePurchase(InAppPurchase.SmartReceiptsPlus)).thenReturn(true);
 
         FallbackTextRenderer.setHeightMeasureSpec(View.MeasureSpec.makeMeasureSpec(25, View.MeasureSpec.EXACTLY));
     }
@@ -486,7 +492,7 @@ public class InteractivePdfBoxTest {
         pdfBoxReportFile.addSection(pdfBoxReportFile.createReceiptsTableSection(trip, receipts,
                 receiptColumns, Collections.<Distance>emptyList(), distanceColumns,
                 Collections.<SumCategoryGroupingResult>emptyList(), summationColumns,
-                Collections.<CategoryGroupingResult>emptyList()));
+                Collections.<CategoryGroupingResult>emptyList(), purchaseWallet));
         pdfBoxReportFile.addSection(pdfBoxReportFile.createReceiptsImagesSection(trip, receipts));
 
         OutputStream outputStream = null;


### PR DESCRIPTION
Now we have new `Omit Default PDF Table` option at the Plus section.

If it's `true` - we don't include the general table to the PDF. If it's `false` - we do.

The default value is `true`, so I changed others Plus options (`Separate Payments by Category` and `Include Categorical Summation`) to `true` too so that the user does not accidentally see a blank report.
