### PR TITLE
Bugfix rating tooltip stackoverflow

### DIFF
--- a/app/src/main/java/co/smartreceipts/android/rating/AppRatingManager.java
+++ b/app/src/main/java/co/smartreceipts/android/rating/AppRatingManager.java
@@ -1,7 +1,5 @@
 package co.smartreceipts.android.rating;
 
-import java.util.concurrent.TimeUnit;
-
 import javax.inject.Inject;
 
 import co.smartreceipts.android.di.scopes.ApplicationScope;
@@ -27,19 +25,28 @@ public class AppRatingManager {
     }
 
     public Single<Boolean> checkIfNeedToAskRating() {
+
+        // FOR TESTING
+
         return appRatingStorage.readAppRatingData()
-                .map(appRatingModel -> {
-                    if (appRatingModel.canShow() && !appRatingModel.isCrashOccurred()) {
-                        // Check if we've reached a rating event
-                        final long daysToMillis = TimeUnit.DAYS.toMillis(1);
-                        if (appRatingModel.getLaunchCount() >= LAUNCHES_UNTIL_PROMPT + appRatingModel.getAdditionalLaunchThreshold() &&
-                                (System.currentTimeMillis() - appRatingModel.getInstallTime()) / daysToMillis >= DAYS_UNTIL_PROMPT) {
-                            return true;
-                        }
-                    }
-                    return false;
-                })
+                .map(appRatingModel -> true)
                 .subscribeOn(Schedulers.io());
+
+//        FOR REAL LIFE
+
+//        return appRatingStorage.readAppRatingData()
+//                .map(appRatingModel -> {
+//                    if (appRatingModel.canShow() && !appRatingModel.isCrashOccurred()) {
+//                        // Check if we've reached a rating event
+//                        final long daysToMillis = TimeUnit.DAYS.toMillis(1);
+//                        if (appRatingModel.getLaunchCount() >= LAUNCHES_UNTIL_PROMPT + appRatingModel.getAdditionalLaunchThreshold() &&
+//                                (System.currentTimeMillis() - appRatingModel.getInstallTime()) / daysToMillis >= DAYS_UNTIL_PROMPT) {
+//                            return true;
+//                        }
+//                    }
+//                    return false;
+//                })
+//                .subscribeOn(Schedulers.io());
     }
 
     public void dontShowRatingPromptAgain() {

--- a/app/src/main/java/co/smartreceipts/android/trips/TripFragment.java
+++ b/app/src/main/java/co/smartreceipts/android/trips/TripFragment.java
@@ -127,8 +127,6 @@ public class TripFragment extends WBListFragment implements TableEventsListener<
         if (toolbar != null) {
             ((AppCompatActivity) getActivity()).setSupportActionBar(toolbar);
         }
-
-        presenter.checkRating();
     }
 
     @Override
@@ -142,6 +140,8 @@ public class TripFragment extends WBListFragment implements TableEventsListener<
         if (actionBar != null) {
             getSupportActionBar().setSubtitle(null);
         }
+
+        presenter.subscribe();
     }
 
     @Override
@@ -149,6 +149,8 @@ public class TripFragment extends WBListFragment implements TableEventsListener<
         Logger.debug(this, "onPause");
 
         tripTableController.unsubscribe(this);
+
+        presenter.unsubscribe();
         super.onPause();
     }
 
@@ -341,22 +343,17 @@ public class TripFragment extends WBListFragment implements TableEventsListener<
     }
 
     public void showRatingTooltip() {
-        tooltip.setQuestion(R.string.rating_tooltip_text, new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                analytics.record(Events.Ratings.UserDeclinedRatingPrompt);
-                navigationHandler.showDialog(new FeedbackDialogFragment());
-                tooltip.hideWithAnimation();
-                presenter.dontShowRatingPrompt();
-            }
-        }, new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                analytics.record(Events.Ratings.UserAcceptedRatingPrompt);
-                navigationHandler.showDialog(new RatingDialogFragment());
-                tooltip.hideWithAnimation();
-                presenter.dontShowRatingPrompt();
-            }
+        Logger.debug(this, "showRatingTooltip");
+        tooltip.setQuestion(R.string.rating_tooltip_text, view -> {
+            analytics.record(Events.Ratings.UserDeclinedRatingPrompt);
+            navigationHandler.showDialog(new FeedbackDialogFragment());
+            tooltip.hideWithAnimation();
+            presenter.dontShowRatingPrompt();
+        }, view -> {
+            analytics.record(Events.Ratings.UserAcceptedRatingPrompt);
+            navigationHandler.showDialog(new RatingDialogFragment());
+            tooltip.hideWithAnimation();
+            presenter.dontShowRatingPrompt();
         });
 
         tooltip.showWithAnimation();

--- a/app/src/main/java/co/smartreceipts/android/trips/TripFragmentPresenter.java
+++ b/app/src/main/java/co/smartreceipts/android/trips/TripFragmentPresenter.java
@@ -1,10 +1,13 @@
 package co.smartreceipts.android.trips;
 
+import java.util.concurrent.TimeUnit;
+
 import javax.inject.Inject;
 
 import co.smartreceipts.android.di.scopes.FragmentScope;
 import co.smartreceipts.android.rating.AppRatingManager;
 import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.disposables.CompositeDisposable;
 import wb.android.storage.StorageManager;
 
 @FragmentScope
@@ -17,18 +20,25 @@ public class TripFragmentPresenter {
     @Inject
     StorageManager storageManager;
 
+    private final CompositeDisposable compositeDisposable = new CompositeDisposable();
+
     @Inject
     public TripFragmentPresenter() {
     }
 
-    public void checkRating() {
-        appRatingManager.checkIfNeedToAskRating()
+    public void unsubscribe() {
+        compositeDisposable.clear();
+    }
+
+    public void subscribe() {
+        compositeDisposable.add(appRatingManager.checkIfNeedToAskRating()
+                .delay(3, TimeUnit.SECONDS) // <-- this magic line resolves StackOverflow error
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(ratingPrompt -> {
                     if (ratingPrompt) {
                         fragment.showRatingTooltip();
                     }
-                });
+                }));
     }
 
     public void dontShowRatingPrompt() {

--- a/app/src/test/java/co/smartreceipts/android/graphs/GraphsInteractorTest.java
+++ b/app/src/test/java/co/smartreceipts/android/graphs/GraphsInteractorTest.java
@@ -78,14 +78,17 @@ public class GraphsInteractorTest {
 
         when(groupingController.getSummationByCategoryAsGraphEntries(trip)).thenReturn(Single.just(entries));
 
-        List<LabeledGraphEntry> sortedEntries = new ArrayList<>(entries);
-        Collections.sort(sortedEntries);
-
         interactor.getSummationByCategories(trip)
                 .test()
                 .assertNoErrors()
                 .assertComplete()
-                .assertResult(GraphUiIndicator.summationByCategory(sortedEntries));
+                .assertValue(graphUiIndicator -> {
+                    if (graphUiIndicator.getGraphType() == GraphUiIndicator.GraphType.SummationByCategory) {
+                        List<? extends BaseEntry> graphUiIndicatorEntries = graphUiIndicator.getEntries();
+                        return graphUiIndicatorEntries.containsAll(entries) && graphUiIndicatorEntries.size() == entries.size();
+                    }
+                    return false;
+                });
     }
 
     @Test
@@ -112,7 +115,13 @@ public class GraphsInteractorTest {
                 .test()
                 .assertNoErrors()
                 .assertComplete()
-                .assertResult(GraphUiIndicator.summationByCategory(expectedEntries));
+                .assertValue(graphUiIndicator -> {
+                    if (graphUiIndicator.getGraphType() == GraphUiIndicator.GraphType.SummationByCategory) {
+                        List<? extends BaseEntry> graphUiIndicatorEntries = graphUiIndicator.getEntries();
+                        return graphUiIndicatorEntries.containsAll(expectedEntries) && graphUiIndicatorEntries.size() == expectedEntries.size();
+                    }
+                    return false;
+                });
     }
 
     @Test


### PR DESCRIPTION
Hi Will,

I was able to reproduce `StackOverflow` error when I use an emulator with Android 7.1 (with Android 7.0  all work normally).

I could not find the recursion there. I also tried to make `TripFragmentPresenter` a bit more similar to our "new" presenters with `CompositeDisposable` and `subscribe()`/`unsubscribe()` methods (BTW it really needs refactoring now :) ) but it didn't resolve the problem - nothing has changed.

I noticed that `StackOverflow` appears only when we are trying to save a new trip or change existing one. And I remembered that not so long ago I was working with a problem when we save the trip at `TripCreateEditFragment` and this `TripCreateEditFragment` should not remain in the back stack. As a result, we are using now `NavigationHandler.navigateToReportInfoFragmentWithoutBackStack()` method which calls `popBackStackImmediate()` and then opens new `ReportInfoFragment`  with trip details.

I just thought that maybe `TripFragment` opens for a very short time (which is almost invisible to the eye) before `ReportInfoFragment` will be opened and Android somehow doesn't have time to draw everything that falls on him. I tried to add a small delay to the rating tooltip before it will try to appear (you can see `.delay(3, TimeUnit.SECONDS)` at `TripFragmentPresenter.subscribe()`) - and it works, the bug did not appear again!

Thus, I think that the problem is fixed but I can't explain how this works. Maybe you as a more experienced developer will be more efficient in understanding of this situation and decision-making
 if it's fixed or maybe not :)

I left the code for quick testing at `AppRatingManager.checkIfNeedToAskRating()`.