### PR TITLE
NonNull payment methods

### DIFF
--- a/app/src/main/java/co/smartreceipts/android/model/Receipt.java
+++ b/app/src/main/java/co/smartreceipts/android/model/Receipt.java
@@ -32,13 +32,11 @@ public interface Receipt extends Parcelable, Priceable, Comparable<Receipt>, Syn
     Trip getTrip();
 
     /**
-     * Gets the payment method associated with this receipt item. This may be {@code null}
-     * if there is no associated payment method.
+     * Gets the payment method associated with this receipt item.
      *
-     * @return the {@link co.smartreceipts.android.model.PaymentMethod} associated with this receipt item or {@code null} if
-     * there is none.
+     * @return the {@link co.smartreceipts.android.model.PaymentMethod} associated with this receipt item.
      */
-    @Nullable
+    @NonNull
     PaymentMethod getPaymentMethod();
 
     /**

--- a/app/src/main/java/co/smartreceipts/android/model/factory/ReceiptBuilderFactory.java
+++ b/app/src/main/java/co/smartreceipts/android/model/factory/ReceiptBuilderFactory.java
@@ -20,6 +20,7 @@ import co.smartreceipts.android.model.Trip;
 import co.smartreceipts.android.model.gson.ExchangeRate;
 import co.smartreceipts.android.model.impl.DefaultReceiptImpl;
 import co.smartreceipts.android.model.impl.ImmutableCategoryImpl;
+import co.smartreceipts.android.model.impl.ImmutablePaymentMethodImpl;
 import co.smartreceipts.android.sync.model.SyncState;
 import co.smartreceipts.android.sync.model.impl.DefaultSyncState;
 
@@ -271,7 +272,7 @@ public class ReceiptBuilderFactory implements BuilderFactory<Receipt> {
     @Override
     @NonNull
     public Receipt build() {
-        return new DefaultReceiptImpl(_id, _index, _trip, _file, _paymentMethod, _name, _category, _comment, _priceBuilderFactory.build(), _taxBuilderFactory.build(), _date, _timezone, _isReimbursable, _isFullPage, _isSelected, _source, _extraEditText1, _extraEditText2, _extraEditText3, _syncState);
+        return new DefaultReceiptImpl(_id, _index, _trip, _file, _paymentMethod == null ? ImmutablePaymentMethodImpl.NONE : _paymentMethod, _name, _category, _comment, _priceBuilderFactory.build(), _taxBuilderFactory.build(), _date, _timezone, _isReimbursable, _isFullPage, _isSelected, _source, _extraEditText1, _extraEditText2, _extraEditText3, _syncState);
     }
 
 }

--- a/app/src/main/java/co/smartreceipts/android/model/impl/DefaultReceiptImpl.java
+++ b/app/src/main/java/co/smartreceipts/android/model/impl/DefaultReceiptImpl.java
@@ -52,7 +52,7 @@ public final class DefaultReceiptImpl implements Receipt {
     private File mFile;
     private long mFileLastModifiedTime;
 
-    public DefaultReceiptImpl(int id, int index, @NonNull Trip trip, @Nullable File file, @Nullable PaymentMethod paymentMethod, @NonNull String name,
+    public DefaultReceiptImpl(int id, int index, @NonNull Trip trip, @Nullable File file, @NonNull PaymentMethod paymentMethod, @NonNull String name,
                               @NonNull Category category, @NonNull String comment, @NonNull Price price, @NonNull Price tax, @NonNull Date date,
                               @NonNull TimeZone timeZone, boolean isReimbursable, boolean isFullPage, boolean isSelected,
                               @NonNull Source source, @Nullable String extraEditText1, @Nullable String extraEditText2, @Nullable String extraEditText3) {
@@ -60,7 +60,7 @@ public final class DefaultReceiptImpl implements Receipt {
 
     }
 
-    public DefaultReceiptImpl(int id, int index, @NonNull Trip trip, @Nullable File file, @Nullable PaymentMethod paymentMethod, @NonNull String name,
+    public DefaultReceiptImpl(int id, int index, @NonNull Trip trip, @Nullable File file, @NonNull PaymentMethod paymentMethod, @NonNull String name,
                               @NonNull Category category, @NonNull String comment, @NonNull Price price, @NonNull Price tax, @NonNull Date date,
                               @NonNull TimeZone timeZone, boolean isReimbursable, boolean isFullPage, boolean isSelected,
                               @NonNull Source source, @Nullable String extraEditText1, @Nullable String extraEditText2, @Nullable String extraEditText3,
@@ -76,12 +76,12 @@ public final class DefaultReceiptImpl implements Receipt {
         mDate = Preconditions.checkNotNull(date);
         mTimeZone = Preconditions.checkNotNull(timeZone);
         mSyncState = Preconditions.checkNotNull(syncState);
+        mPaymentMethod = Preconditions.checkNotNull(paymentMethod);
 
         mId = id;
         mIndex = index;
         mFile = file;
         mFileLastModifiedTime = file != null ? file.lastModified() : -1;
-        mPaymentMethod = paymentMethod;
         mIsReimbursable = isReimbursable;
         mIsFullPage = isFullPage;
         mExtraEditText1 = extraEditText1;
@@ -126,7 +126,7 @@ public final class DefaultReceiptImpl implements Receipt {
         return mTrip;
     }
 
-    @Nullable
+    @NonNull
     @Override
     public PaymentMethod getPaymentMethod() {
         return mPaymentMethod;
@@ -393,8 +393,7 @@ public final class DefaultReceiptImpl implements Receipt {
         if (mIsReimbursable != that.mIsReimbursable) return false;
         if (mIsFullPage != that.mIsFullPage) return false;
         if (!mTrip.equals(that.mTrip)) return false;
-        if (mPaymentMethod != null ? !mPaymentMethod.equals(that.mPaymentMethod) : that.mPaymentMethod != null)
-            return false;
+        if (!mPaymentMethod.equals(that.mPaymentMethod)) return false;
         if (!mName.equals(that.mName)) return false;
         if (!mComment.equals(that.mComment)) return false;
         if (!mCategory.equals(that.mCategory)) return false;
@@ -417,7 +416,7 @@ public final class DefaultReceiptImpl implements Receipt {
     public int hashCode() {
         int result = mId;
         result = 31 * result + mTrip.hashCode();
-        result = 31 * result + (mPaymentMethod != null ? mPaymentMethod.hashCode() : 0);
+        result = 31 * result + mPaymentMethod.hashCode();
         result = 31 * result + mName.hashCode();
         result = 31 * result + mComment.hashCode();
         result = 31 * result + mCategory.hashCode();

--- a/app/src/main/java/co/smartreceipts/android/model/impl/ImmutablePaymentMethodImpl.java
+++ b/app/src/main/java/co/smartreceipts/android/model/impl/ImmutablePaymentMethodImpl.java
@@ -1,11 +1,13 @@
 package co.smartreceipts.android.model.impl;
 
+import android.content.res.Resources;
 import android.os.Parcel;
 import android.support.annotation.NonNull;
 
 import com.google.common.base.Preconditions;
 
 import co.smartreceipts.android.model.PaymentMethod;
+import co.smartreceipts.android.model.factory.PaymentMethodBuilderFactory;
 import co.smartreceipts.android.sync.model.SyncState;
 import co.smartreceipts.android.sync.model.impl.DefaultSyncState;
 
@@ -15,6 +17,10 @@ import co.smartreceipts.android.sync.model.impl.DefaultSyncState;
  * @author Will Baumann
  */
 public final class ImmutablePaymentMethodImpl implements PaymentMethod {
+
+    // TODO: 15.07.2017 maybe would be good to delete 'Unspecified' payment method
+    // TODO: 16.07.2017 check tests
+    public static final PaymentMethod NONE = new PaymentMethodBuilderFactory().setMethod(Resources.getSystem().getString(android.R.string.untitled)).build();
 
     private final int mId;
     private final String mMethod;

--- a/app/src/main/java/co/smartreceipts/android/model/impl/ImmutablePaymentMethodImpl.java
+++ b/app/src/main/java/co/smartreceipts/android/model/impl/ImmutablePaymentMethodImpl.java
@@ -17,9 +17,7 @@ import co.smartreceipts.android.sync.model.impl.DefaultSyncState;
  * @author Will Baumann
  */
 public final class ImmutablePaymentMethodImpl implements PaymentMethod {
-
-    // TODO: 15.07.2017 maybe would be good to delete 'Unspecified' payment method
-    // TODO: 16.07.2017 check tests
+    
     public static final PaymentMethod NONE = new PaymentMethodBuilderFactory().setMethod(Resources.getSystem().getString(android.R.string.untitled)).build();
 
     private final int mId;

--- a/app/src/main/java/co/smartreceipts/android/persistence/database/controllers/grouping/GroupingController.java
+++ b/app/src/main/java/co/smartreceipts/android/persistence/database/controllers/grouping/GroupingController.java
@@ -18,6 +18,7 @@ import co.smartreceipts.android.model.PriceCurrency;
 import co.smartreceipts.android.model.Receipt;
 import co.smartreceipts.android.model.Trip;
 import co.smartreceipts.android.model.factory.PriceBuilderFactory;
+import co.smartreceipts.android.model.impl.ImmutablePaymentMethodImpl;
 import co.smartreceipts.android.persistence.DatabaseHelper;
 import co.smartreceipts.android.persistence.database.controllers.grouping.results.CategoryGroupingResult;
 import co.smartreceipts.android.persistence.database.controllers.grouping.results.SumPaymentMethodGroupingResult;
@@ -82,7 +83,7 @@ public class GroupingController {
     private Observable<SumPaymentMethodGroupingResult> getSummationByPaymentMethod(Trip trip) {
         return getReceiptsStream(trip)
                 .filter(receipt -> !preferenceManager.get(UserPreference.Receipts.OnlyIncludeReimbursable) || receipt.isReimbursable())
-                .filter(receipt -> receipt.getPaymentMethod() != null) // thus, we ignore receipts without defined payment method
+                .filter(receipt -> !receipt.getPaymentMethod().equals(ImmutablePaymentMethodImpl.NONE)) // thus, we ignore receipts without defined payment method
                 .groupBy(Receipt::getPaymentMethod)
                 .flatMap(paymentMethodReceiptGroupedObservable -> paymentMethodReceiptGroupedObservable
                         .toList()

--- a/app/src/main/java/co/smartreceipts/android/receipts/editor/ReceiptCreateEditFragment.java
+++ b/app/src/main/java/co/smartreceipts/android/receipts/editor/ReceiptCreateEditFragment.java
@@ -28,15 +28,10 @@ import android.widget.Spinner;
 import android.widget.Toast;
 
 import java.io.File;
-import java.math.BigDecimal;
 import java.sql.Date;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.GregorianCalendar;
 import java.util.List;
-import java.util.Locale;
-import java.util.TimeZone;
 
 import javax.inject.Inject;
 
@@ -58,7 +53,7 @@ import co.smartreceipts.android.model.PaymentMethod;
 import co.smartreceipts.android.model.Receipt;
 import co.smartreceipts.android.model.Trip;
 import co.smartreceipts.android.model.gson.ExchangeRate;
-import co.smartreceipts.android.model.utils.ModelUtils;
+import co.smartreceipts.android.model.impl.ImmutablePaymentMethodImpl;
 import co.smartreceipts.android.ocr.apis.model.OcrResponse;
 import co.smartreceipts.android.ocr.util.OcrResponseParser;
 import co.smartreceipts.android.ocr.widget.tooltip.OcrInformationalTooltipFragment;
@@ -467,18 +462,19 @@ public class ReceiptCreateEditFragment extends WBFragment implements View.OnFocu
             @Override
             public void onGetSuccess(@NonNull List<PaymentMethod> list) {
                 if (isAdded()) {
-                    paymentMethodsAdapter = new ArrayAdapter<>(getActivity(), android.R.layout.simple_spinner_item, list);
+                    List<PaymentMethod> paymentMethods = new ArrayList<>(list);
+                    paymentMethods.add(0, ImmutablePaymentMethodImpl.NONE);
+
+                    paymentMethodsAdapter = new ArrayAdapter<>(getActivity(), android.R.layout.simple_spinner_item, paymentMethods);
                     paymentMethodsAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
                     paymentMethodsSpinner.setAdapter(paymentMethodsAdapter);
                     if (presenter.isUsePaymentMethods()) {
                         paymentMethodsContainer.setVisibility(View.VISIBLE);
                         if (getReceipt() != null) {
                             final PaymentMethod oldPaymentMethod = getReceipt().getPaymentMethod();
-                            if (oldPaymentMethod != null) {
-                                final int paymentIdx = paymentMethodsAdapter.getPosition(oldPaymentMethod);
-                                if (paymentIdx > 0) {
-                                    paymentMethodsSpinner.setSelection(paymentIdx);
-                                }
+                            final int paymentIdx = paymentMethodsAdapter.getPosition(oldPaymentMethod);
+                            if (paymentIdx > 0) {
+                                paymentMethodsSpinner.setSelection(paymentIdx);
                             }
                         }
                     }


### PR DESCRIPTION
Now Payment Methods must be @NonNull and we have a new one `ImmutablePaymentMethodImpl.NONE` which is default for all new Receipts.

It would be pretty hard to use a custom string for this one due to lack of `Context` and I decided to use Android system string `<Untitled>`. I think it's quite suitable for our case :)

New Payment Method is visible for user at the payment methods spinner at position 0 from the `ReceiptCreateEditFragment` but it's not present at the payment methods editor. Also receipts with `ImmutablePaymentMethodImpl.NONE` payment method are not counted in the payment methods chart.

Maybe now we can remove `Unspecified` payment method from defaults? :)