### PR TITLE
Backup reminder

### DIFF
--- a/app/src/main/java/co/smartreceipts/android/activities/di/SmartReceiptsActivitySubcomponent.java
+++ b/app/src/main/java/co/smartreceipts/android/activities/di/SmartReceiptsActivitySubcomponent.java
@@ -10,6 +10,7 @@ import co.smartreceipts.android.di.scopes.ActivityScope;
 import co.smartreceipts.android.imports.intents.di.IntentImportInformationModule;
 import co.smartreceipts.android.sync.BackupProvidersManager;
 import co.smartreceipts.android.widget.tooltip.report.ReportTooltipInteractor;
+import co.smartreceipts.android.widget.tooltip.report.backup.BackupReminderTooltipManager;
 import co.smartreceipts.android.widget.tooltip.report.generate.GenerateInfoTooltipManager;
 import dagger.Module;
 import dagger.Provides;
@@ -44,9 +45,10 @@ public interface SmartReceiptsActivitySubcomponent extends AndroidInjector<Smart
                                                                NavigationHandler navigationHandler,
                                                                BackupProvidersManager backupProvidersManager,
                                                                Analytics analytics,
-                                                               GenerateInfoTooltipManager tooltipManager) {
+                                                               GenerateInfoTooltipManager generateInfoTooltipManager,
+                                                               BackupReminderTooltipManager backupReminderTooltipManager) {
             return new ReportTooltipInteractor<>(activity, navigationHandler, backupProvidersManager,
-                    analytics, tooltipManager);
+                    analytics, generateInfoTooltipManager, backupReminderTooltipManager);
         }
     }
 }

--- a/app/src/main/java/co/smartreceipts/android/analytics/events/Events.java
+++ b/app/src/main/java/co/smartreceipts/android/analytics/events/Events.java
@@ -80,6 +80,7 @@ public final class Events {
     public static final class Informational {
         public static final Event ConfigureReport = new DefaultEvent(Category.Informational, "ConfigureReport");
         public static final Event ClickedGenerateReportTip = new DefaultEvent(Category.Informational, "ClickedGenerateReportTip");
+        public static final Event ClickedBackupReminderTip = new DefaultEvent(Category.Informational, "ClickedBackupReminderTip");
         public static final Event ManageCategories = new DefaultEvent(Category.Informational, "ClickedManageCategories");
         public static final Event ManagePaymentMethods = new DefaultEvent(Category.Informational, "ClickedManagePaymentMethods");
     }

--- a/app/src/main/java/co/smartreceipts/android/date/DateUtils.java
+++ b/app/src/main/java/co/smartreceipts/android/date/DateUtils.java
@@ -15,31 +15,31 @@ import java.util.regex.Pattern;
 
 public class DateUtils {
 
-	public static final String DEFAULT_SEPARATOR = "/";
-	private static String separator;
-	
-	private DateUtils() {
-		throw new RuntimeException("This class uses static calls only. It cannot be instantianted");
-	}
-	
-	public static String getDateSeparator(Context context) {
-		if (separator == null) {
-	        String dateString = DateFormat.getDateFormat(context).format(new java.util.Date());
-	        Matcher matcher = Pattern.compile("[^\\w]").matcher(dateString);
-	        if (!matcher.find()) {
-	        	separator = DEFAULT_SEPARATOR;
-	        }
-	        else {
-	        	separator = matcher.group(0);
-	        }
-		}
-		return separator;
+    public static final String DEFAULT_SEPARATOR = "/";
+    private static String separator;
+
+    private DateUtils() {
+        throw new RuntimeException("This class uses static calls only. It cannot be instantianted");
     }
-	
-	public static String getCurrentDateAsYYYY_MM_DDString() {
-		SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy_MM_dd", Locale.getDefault());
-		return dateFormat.format(Calendar.getInstance().getTime());
-	}
+
+    public static String getDateSeparator(Context context) {
+        if (separator == null) {
+            String dateString = DateFormat.getDateFormat(context).format(new java.util.Date());
+            Matcher matcher = Pattern.compile("[^\\w]").matcher(dateString);
+            if (!matcher.find()) {
+                separator = DEFAULT_SEPARATOR;
+            }
+            else {
+                separator = matcher.group(0);
+            }
+        }
+        return separator;
+    }
+
+    public static String getCurrentDateAsYYYY_MM_DDString() {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy_MM_dd", Locale.getDefault());
+        return dateFormat.format(Calendar.getInstance().getTime());
+    }
 
     public static boolean isToday(@NonNull Date date) {
 

--- a/app/src/main/java/co/smartreceipts/android/di/BaseAppModule.java
+++ b/app/src/main/java/co/smartreceipts/android/di/BaseAppModule.java
@@ -21,6 +21,8 @@ import co.smartreceipts.android.persistence.database.defaults.WhiteLabelFriendly
 import co.smartreceipts.android.rating.data.AppRatingPreferencesStorage;
 import co.smartreceipts.android.rating.data.AppRatingStorage;
 import co.smartreceipts.android.settings.UserPreferenceManager;
+import co.smartreceipts.android.widget.tooltip.report.backup.data.BackupReminderPreferencesStorage;
+import co.smartreceipts.android.widget.tooltip.report.backup.data.BackupReminderTooltipStorage;
 import co.smartreceipts.android.widget.tooltip.report.generate.data.GenerateInfoTooltipPreferencesStorage;
 import co.smartreceipts.android.widget.tooltip.report.generate.data.GenerateInfoTooltipStorage;
 import dagger.Module;
@@ -106,6 +108,12 @@ public class BaseAppModule {
     @Provides
     @ApplicationScope
     public static GenerateInfoTooltipStorage provideGenerateInfoTooltipStorage(GenerateInfoTooltipPreferencesStorage storage) {
+        return storage;
+    }
+
+    @Provides
+    @ApplicationScope
+    public static BackupReminderTooltipStorage provideBackupReminderTooltipStorage (BackupReminderPreferencesStorage storage) {
         return storage;
     }
 }

--- a/app/src/main/java/co/smartreceipts/android/fragments/ReportInfoFragment.java
+++ b/app/src/main/java/co/smartreceipts/android/fragments/ReportInfoFragment.java
@@ -32,10 +32,11 @@ import co.smartreceipts.android.persistence.database.operations.DatabaseOperatio
 import co.smartreceipts.android.utils.cache.FragmentStateCache;
 import co.smartreceipts.android.utils.log.Logger;
 import co.smartreceipts.android.widget.tooltip.report.ReportTooltipFragment;
+import co.smartreceipts.android.widget.tooltip.report.backup.BackupNavigator;
 import co.smartreceipts.android.widget.tooltip.report.generate.GenerateNavigator;
 import dagger.android.support.AndroidSupportInjection;
 
-public class ReportInfoFragment extends WBFragment implements GenerateNavigator {
+public class ReportInfoFragment extends WBFragment implements GenerateNavigator, BackupNavigator {
 
     public static final String TAG = ReportInfoFragment.class.getSimpleName();
 
@@ -200,5 +201,10 @@ public class ReportInfoFragment extends WBFragment implements GenerateNavigator 
     @Override
     public void navigateToGenerateTab() {
         viewPager.setCurrentItem(fragmentPagerAdapter.getGenerateTabPosition(), true);
+    }
+
+    @Override
+    public void navigateToBackup() {
+        navigationHandler.navigateToBackupMenu();
     }
 }

--- a/app/src/main/java/co/smartreceipts/android/receipts/editor/ReceiptCreateEditFragment.java
+++ b/app/src/main/java/co/smartreceipts/android/receipts/editor/ReceiptCreateEditFragment.java
@@ -67,6 +67,7 @@ import co.smartreceipts.android.utils.cache.FragmentStateCache;
 import co.smartreceipts.android.utils.log.Logger;
 import co.smartreceipts.android.widget.NetworkRequestAwareEditText;
 import co.smartreceipts.android.widget.UserSelectionTrackingOnItemSelectedListener;
+import co.smartreceipts.android.widget.tooltip.report.backup.data.BackupReminderTooltipStorage;
 import dagger.android.support.AndroidSupportInjection;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
@@ -100,7 +101,8 @@ public class ReceiptCreateEditFragment extends WBFragment implements View.OnFocu
     NavigationHandler navigationHandler;
     @Inject
     FragmentStateCache fragmentStateCache;
-
+    @Inject
+    BackupReminderTooltipStorage backupReminderTooltipStorage;
 
     @Inject
     ReceiptCreateEditFragmentPresenter presenter;
@@ -750,6 +752,8 @@ public class ReceiptCreateEditFragment extends WBFragment implements View.OnFocu
 
             analytics.record(getReceipt() == null ? Events.Receipts.PersistNewReceipt : Events.Receipts.PersistUpdateReceipt);
             dateManager.setDateEditTextListenerDialogHolder(null);
+
+            backupReminderTooltipStorage.setOneMoreNewReceipt();
 
 
             navigationHandler.navigateToReportInfoFragment(getParentTrip());

--- a/app/src/main/java/co/smartreceipts/android/sync/widget/backups/ExportBackupWorkerProgressDialogFragment.java
+++ b/app/src/main/java/co/smartreceipts/android/sync/widget/backups/ExportBackupWorkerProgressDialogFragment.java
@@ -17,6 +17,7 @@ import co.smartreceipts.android.analytics.Analytics;
 import co.smartreceipts.android.analytics.events.ErrorEvent;
 import co.smartreceipts.android.persistence.PersistenceManager;
 import co.smartreceipts.android.sync.manual.ManualBackupAndRestoreTaskCache;
+import co.smartreceipts.android.widget.tooltip.report.backup.data.BackupReminderTooltipStorage;
 import dagger.android.support.AndroidSupportInjection;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
@@ -28,6 +29,8 @@ public class ExportBackupWorkerProgressDialogFragment extends DialogFragment {
     PersistenceManager persistenceManager;
     @Inject
     Analytics analytics;
+    @Inject
+    BackupReminderTooltipStorage backupReminderTooltipStorage;
 
     private ManualBackupAndRestoreTaskCache manualBackupAndRestoreTaskCache;
     private Disposable disposable;
@@ -70,6 +73,7 @@ public class ExportBackupWorkerProgressDialogFragment extends DialogFragment {
                         sentIntent.setType("application/octet-stream");
                         sentIntent.putExtra(Intent.EXTRA_STREAM, uri);
                         getActivity().startActivity(Intent.createChooser(sentIntent, getString(R.string.export)));
+                        backupReminderTooltipStorage.setLastManualBackupDate();
                     } else {
                         Toast.makeText(getContext(), getString(R.string.EXPORT_ERROR), Toast.LENGTH_LONG).show();
                     }

--- a/app/src/main/java/co/smartreceipts/android/widget/tooltip/Tooltip.java
+++ b/app/src/main/java/co/smartreceipts/android/widget/tooltip/Tooltip.java
@@ -61,6 +61,17 @@ public class Tooltip extends RelativeLayout {
         setTooltipClickListener(tooltipClickListener);
     }
 
+    public void setInfoWithIcon(@StringRes int infoStringId, @Nullable OnClickListener tooltipClickListener,
+                        @Nullable OnClickListener closeClickListener, Object... formatArgs) {
+        setInfoMessage(getContext().getString(infoStringId, formatArgs));
+        setTooltipClickListener(tooltipClickListener);
+        showCloseIcon(closeClickListener);
+
+        errorIcon.setVisibility(VISIBLE);
+        buttonNo.setVisibility(GONE);
+        buttonYes.setVisibility(GONE);
+    }
+
     public void setInfo(@StringRes int infoStringId, @Nullable OnClickListener tooltipClickListener, @Nullable OnClickListener closeClickListener) {
         setInfoMessage(infoStringId);
         setTooltipClickListener(tooltipClickListener);

--- a/app/src/main/java/co/smartreceipts/android/widget/tooltip/TooltipManager.java
+++ b/app/src/main/java/co/smartreceipts/android/widget/tooltip/TooltipManager.java
@@ -1,0 +1,6 @@
+package co.smartreceipts.android.widget.tooltip;
+
+public interface TooltipManager {
+
+    void tooltipWasDismissed();
+}

--- a/app/src/main/java/co/smartreceipts/android/widget/tooltip/report/ReportTooltipPresenter.java
+++ b/app/src/main/java/co/smartreceipts/android/widget/tooltip/report/ReportTooltipPresenter.java
@@ -46,6 +46,8 @@ public class ReportTooltipPresenter extends BasePresenter<TooltipView, ReportToo
                     Logger.info(ReportTooltipPresenter.this, "User clicked on {} tooltip", uiIndicator);
                     if (uiIndicator.getState() == ReportTooltipUiIndicator.State.GenerateInfo) {
                         analytics.record(Events.Informational.ClickedGenerateReportTip);
+                    } else if (uiIndicator.getState() == ReportTooltipUiIndicator.State.BackupReminder) {
+                        analytics.record(Events.Informational.ClickedBackupReminderTip);
                     }
                 })
                 .subscribe(uiIndicator -> {
@@ -55,6 +57,8 @@ public class ReportTooltipPresenter extends BasePresenter<TooltipView, ReportToo
                     } else if (uiIndicator.getState() == ReportTooltipUiIndicator.State.GenerateInfo) {
                         // Note: The actual click logic is in the view (probably need to clean up dagger for this to be cleaner)
                         interactor.generateInfoTooltipClosed();
+                    } else if (uiIndicator.getState() == ReportTooltipUiIndicator.State.BackupReminder) {
+                        interactor.backupReminderTooltipClosed();
                     }
                 }));
 
@@ -63,6 +67,8 @@ public class ReportTooltipPresenter extends BasePresenter<TooltipView, ReportToo
                     view.present(ReportTooltipUiIndicator.none());
                     if (uiIndicator.getState() == ReportTooltipUiIndicator.State.GenerateInfo) {
                         interactor.generateInfoTooltipClosed();
+                    } else if (uiIndicator.getState() == ReportTooltipUiIndicator.State.BackupReminder) {
+                        interactor.backupReminderTooltipClosed();
                     }
                 }));
     }

--- a/app/src/main/java/co/smartreceipts/android/widget/tooltip/report/ReportTooltipUiIndicator.java
+++ b/app/src/main/java/co/smartreceipts/android/widget/tooltip/report/ReportTooltipUiIndicator.java
@@ -11,7 +11,7 @@ import co.smartreceipts.android.sync.errors.SyncErrorType;
 public class ReportTooltipUiIndicator {
 
     public enum State {
-        SyncError, GenerateInfo, None
+        SyncError, GenerateInfo, BackupReminder, None
     }
 
     private final State state;
@@ -30,6 +30,11 @@ public class ReportTooltipUiIndicator {
     @NonNull
     public static ReportTooltipUiIndicator generateInfo() {
         return new ReportTooltipUiIndicator(State.GenerateInfo, null);
+    }
+
+    @NonNull
+    public static ReportTooltipUiIndicator backupReminder() {
+        return new ReportTooltipUiIndicator(State.BackupReminder, null);
     }
 
     @NonNull

--- a/app/src/main/java/co/smartreceipts/android/widget/tooltip/report/ReportTooltipUiIndicator.java
+++ b/app/src/main/java/co/smartreceipts/android/widget/tooltip/report/ReportTooltipUiIndicator.java
@@ -16,30 +16,33 @@ public class ReportTooltipUiIndicator {
 
     private final State state;
     private final Optional<SyncErrorType> errorType;
+    private final Optional<Integer> daysSinceBackup;
 
-    private ReportTooltipUiIndicator(@NonNull State state, @Nullable SyncErrorType errorType) {
+    private ReportTooltipUiIndicator(@NonNull State state, @Nullable SyncErrorType errorType,
+                                     @Nullable Integer daysSinceLastBackup) {
         this.state = Preconditions.checkNotNull(state);
         this.errorType = Optional.ofNullable(errorType);
+        this.daysSinceBackup = Optional.ofNullable(daysSinceLastBackup);
     }
 
     @NonNull
     public static ReportTooltipUiIndicator syncError(@NonNull SyncErrorType errorType) {
-        return new ReportTooltipUiIndicator(State.SyncError, errorType);
+        return new ReportTooltipUiIndicator(State.SyncError, errorType, null);
     }
 
     @NonNull
     public static ReportTooltipUiIndicator generateInfo() {
-        return new ReportTooltipUiIndicator(State.GenerateInfo, null);
+        return new ReportTooltipUiIndicator(State.GenerateInfo, null, null);
     }
 
     @NonNull
-    public static ReportTooltipUiIndicator backupReminder() {
-        return new ReportTooltipUiIndicator(State.BackupReminder, null);
+    public static ReportTooltipUiIndicator backupReminder(int days) {
+        return new ReportTooltipUiIndicator(State.BackupReminder, null, days);
     }
 
     @NonNull
     public static ReportTooltipUiIndicator none() {
-        return new ReportTooltipUiIndicator(State.None, null);
+        return new ReportTooltipUiIndicator(State.None, null, null);
     }
 
     public State getState() {
@@ -50,15 +53,20 @@ public class ReportTooltipUiIndicator {
         return errorType;
     }
 
+    public Optional<Integer> getDaysSinceBackup() {
+        return daysSinceBackup;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        ReportTooltipUiIndicator that = (ReportTooltipUiIndicator) o;
+        ReportTooltipUiIndicator indicator = (ReportTooltipUiIndicator) o;
 
-        if (state != that.state) return false;
-        return errorType.equals(that.errorType);
+        if (state != indicator.state) return false;
+        if (!errorType.equals(indicator.errorType)) return false;
+        return daysSinceBackup.equals(indicator.daysSinceBackup);
 
     }
 
@@ -66,6 +74,7 @@ public class ReportTooltipUiIndicator {
     public int hashCode() {
         int result = state.hashCode();
         result = 31 * result + errorType.hashCode();
+        result = 31 * result + daysSinceBackup.hashCode();
         return result;
     }
 }

--- a/app/src/main/java/co/smartreceipts/android/widget/tooltip/report/backup/BackupNavigator.java
+++ b/app/src/main/java/co/smartreceipts/android/widget/tooltip/report/backup/BackupNavigator.java
@@ -1,0 +1,6 @@
+package co.smartreceipts.android.widget.tooltip.report.backup;
+
+public interface BackupNavigator {
+
+    void navigateToBackup();
+}

--- a/app/src/main/java/co/smartreceipts/android/widget/tooltip/report/backup/BackupReminderTooltipManager.java
+++ b/app/src/main/java/co/smartreceipts/android/widget/tooltip/report/backup/BackupReminderTooltipManager.java
@@ -1,0 +1,35 @@
+package co.smartreceipts.android.widget.tooltip.report.backup;
+
+import javax.inject.Inject;
+
+import co.smartreceipts.android.di.scopes.ApplicationScope;
+import co.smartreceipts.android.persistence.DatabaseHelper;
+import co.smartreceipts.android.sync.BackupProvidersManager;
+import co.smartreceipts.android.sync.provider.SyncProvider;
+
+@ApplicationScope
+public class BackupReminderTooltipManager {
+
+    private final DatabaseHelper databaseHelper;
+    private final BackupProvidersManager backupProvidersManager;
+
+    @Inject
+    public BackupReminderTooltipManager(DatabaseHelper databaseHelper, BackupProvidersManager backupProvidersManager) {
+        this.databaseHelper = databaseHelper;
+        this.backupProvidersManager = backupProvidersManager;
+    }
+
+    private void needToShowBackupReminderTooltip() {
+        // TODO: 22.07.2017 count getLastDatabaseSyncTime and date if user dismissed the tooltip
+
+        if (backupProvidersManager.getSyncProvider() == SyncProvider.None) { // auto-backups are disabled
+
+        } else {
+
+        }
+
+
+        backupProvidersManager.getLastDatabaseSyncTime();
+
+    }
+}

--- a/app/src/main/java/co/smartreceipts/android/widget/tooltip/report/backup/BackupReminderTooltipManager.java
+++ b/app/src/main/java/co/smartreceipts/android/widget/tooltip/report/backup/BackupReminderTooltipManager.java
@@ -35,7 +35,7 @@ public class BackupReminderTooltipManager implements TooltipManager {
         int daysLimit = DAYS_WITHOUT_BACKUP_LIMIT + DAYS_WITHOUT_BACKUP_LIMIT * prolongationsCount;
 
         if (backupProvidersManager.getSyncProvider() == SyncProvider.None && // disabled auto backups
-                backupReminderTooltipStorage.getReceiptsCountWithoutBackup() > receiptsLimit) { // and user has a lot of new receipts since last backup
+                backupReminderTooltipStorage.getReceiptsCountWithoutBackup() >= receiptsLimit) { // and user has a lot of new receipts since last backup
 
             long lastManualBackupTime = backupReminderTooltipStorage.getLastManualBackupDate().getTime();
 
@@ -43,7 +43,7 @@ public class BackupReminderTooltipManager implements TooltipManager {
                 return Maybe.just(NO_PREVIOUS_BACKUPS_DAY);
             } else {
                 int daysSinceLastManualBackup = (int) TimeUnit.MILLISECONDS.toDays(Math.abs(lastManualBackupTime - System.currentTimeMillis()));
-                return daysSinceLastManualBackup > daysLimit ? Maybe.just(daysSinceLastManualBackup) : Maybe.empty();
+                return daysSinceLastManualBackup >= daysLimit ? Maybe.just(daysSinceLastManualBackup) : Maybe.empty();
             }
         } else {
             return Maybe.empty();

--- a/app/src/main/java/co/smartreceipts/android/widget/tooltip/report/backup/BackupReminderTooltipManager.java
+++ b/app/src/main/java/co/smartreceipts/android/widget/tooltip/report/backup/BackupReminderTooltipManager.java
@@ -1,35 +1,57 @@
 package co.smartreceipts.android.widget.tooltip.report.backup;
 
+import java.util.concurrent.TimeUnit;
+
 import javax.inject.Inject;
 
 import co.smartreceipts.android.di.scopes.ApplicationScope;
-import co.smartreceipts.android.persistence.DatabaseHelper;
 import co.smartreceipts.android.sync.BackupProvidersManager;
 import co.smartreceipts.android.sync.provider.SyncProvider;
+import co.smartreceipts.android.widget.tooltip.TooltipManager;
+import co.smartreceipts.android.widget.tooltip.report.backup.data.BackupReminderTooltipStorage;
+import io.reactivex.Maybe;
 
 @ApplicationScope
-public class BackupReminderTooltipManager {
+public class BackupReminderTooltipManager implements TooltipManager {
 
-    private final DatabaseHelper databaseHelper;
+    private static final int DAYS_WITHOUT_BACKUP_LIMIT = 10;
+    private static final int NEW_RECEIPTS_LIMIT = 15;
+    private static final int NO_PREVIOUS_BACKUPS_DAY = -1;
+
     private final BackupProvidersManager backupProvidersManager;
+    private final BackupReminderTooltipStorage backupReminderTooltipStorage;
 
     @Inject
-    public BackupReminderTooltipManager(DatabaseHelper databaseHelper, BackupProvidersManager backupProvidersManager) {
-        this.databaseHelper = databaseHelper;
+    public BackupReminderTooltipManager(BackupProvidersManager backupProvidersManager,
+                                        BackupReminderTooltipStorage backupReminderTooltipStorage) {
         this.backupProvidersManager = backupProvidersManager;
+        this.backupReminderTooltipStorage = backupReminderTooltipStorage;
     }
 
-    private void needToShowBackupReminderTooltip() {
-        // TODO: 22.07.2017 count getLastDatabaseSyncTime and date if user dismissed the tooltip
+    public Maybe<Integer> needToShowBackupReminder() {
 
-        if (backupProvidersManager.getSyncProvider() == SyncProvider.None) { // auto-backups are disabled
+        int prolongationsCount = backupReminderTooltipStorage.getProlongationsCount();
+        int receiptsLimit = NEW_RECEIPTS_LIMIT + NEW_RECEIPTS_LIMIT * prolongationsCount;
+        int daysLimit = DAYS_WITHOUT_BACKUP_LIMIT + DAYS_WITHOUT_BACKUP_LIMIT * prolongationsCount;
 
+        if (backupProvidersManager.getSyncProvider() == SyncProvider.None && // disabled auto backups
+                backupReminderTooltipStorage.getReceiptsCountWithoutBackup() > receiptsLimit) { // and user has a lot of new receipts since last backup
+
+            long lastManualBackupTime = backupReminderTooltipStorage.getLastManualBackupDate().getTime();
+
+            if (lastManualBackupTime == 0) { // if we didn't track any manual backup yet
+                return Maybe.just(NO_PREVIOUS_BACKUPS_DAY);
+            } else {
+                int daysSinceLastManualBackup = (int) TimeUnit.MILLISECONDS.toDays(Math.abs(lastManualBackupTime - System.currentTimeMillis()));
+                return daysSinceLastManualBackup > daysLimit ? Maybe.just(daysSinceLastManualBackup) : Maybe.empty();
+            }
         } else {
-
+            return Maybe.empty();
         }
+    }
 
-
-        backupProvidersManager.getLastDatabaseSyncTime();
-
+    @Override
+    public void tooltipWasDismissed() {
+        backupReminderTooltipStorage.prolongReminder();
     }
 }

--- a/app/src/main/java/co/smartreceipts/android/widget/tooltip/report/backup/data/BackupReminderPreferencesStorage.java
+++ b/app/src/main/java/co/smartreceipts/android/widget/tooltip/report/backup/data/BackupReminderPreferencesStorage.java
@@ -1,0 +1,16 @@
+package co.smartreceipts.android.widget.tooltip.report.backup.data;
+
+import java.sql.Date;
+
+public class BackupReminderPreferencesStorage implements BackupReminderTooltipStorage {
+
+    @Override
+    public boolean isAutomaticBackupsEnabled() {
+        return false;
+    }
+
+    @Override
+    public Date getLastBackupDate() {
+        return null;
+    }
+}

--- a/app/src/main/java/co/smartreceipts/android/widget/tooltip/report/backup/data/BackupReminderPreferencesStorage.java
+++ b/app/src/main/java/co/smartreceipts/android/widget/tooltip/report/backup/data/BackupReminderPreferencesStorage.java
@@ -1,16 +1,113 @@
 package co.smartreceipts.android.widget.tooltip.report.backup.data;
 
+import android.content.Context;
+import android.content.SharedPreferences;
+
 import java.sql.Date;
 
+import javax.inject.Inject;
+
+import co.smartreceipts.android.di.scopes.ApplicationScope;
+import co.smartreceipts.android.sync.BackupProvidersManager;
+import co.smartreceipts.android.sync.provider.SyncProvider;
+import co.smartreceipts.android.utils.log.Logger;
+
+@ApplicationScope
 public class BackupReminderPreferencesStorage implements BackupReminderTooltipStorage {
 
-    @Override
-    public boolean isAutomaticBackupsEnabled() {
-        return false;
+    private final Context appContext;
+    private final BackupProvidersManager backupProvidersManager;
+
+    private final static class Keys {
+        /**
+         * Key to get preferences related to the backup reminder tooltip
+         */
+        private static final String BACKUP_TOOLTIP_PREFERENCES = "Backup Tooltip Preferences";
+        /**
+         * Key to track the date when the user created manual backup last time
+         */
+        private static final String USER_CREATED_MANUAL_BACKUP = "Last Manual Backup Date";
+        /**
+         * Key to track the count of new receipts that the user created after last manual backup
+         */
+        private static final String NEW_RECEIPTS_SINCE_LAST_MANUAL_BACKUP = "Receipts count since last Manual Backup";
+        /**
+         * Key to track how many times the user dismissed this reminder and did no manual backup
+         */
+        private static final String PROLONGATION_COUNTER = "Prolongation count";
+    }
+
+    @Inject
+    public BackupReminderPreferencesStorage(Context appContext, BackupProvidersManager backupProvidersManager) {
+        this.appContext = appContext.getApplicationContext();
+        this.backupProvidersManager = backupProvidersManager;
+
+        this.backupProvidersManager.registerChangeListener(newProvider -> {
+            if (newProvider == SyncProvider.None) {
+                clearTrackedValues();
+            }
+        });
     }
 
     @Override
-    public Date getLastBackupDate() {
-        return null;
+    public void setLastManualBackupDate() {
+        getSharedPreferences().edit()
+                .putLong(Keys.USER_CREATED_MANUAL_BACKUP, System.currentTimeMillis())
+                .putInt(Keys.NEW_RECEIPTS_SINCE_LAST_MANUAL_BACKUP, 0)
+                .putInt(Keys.PROLONGATION_COUNTER, 0)
+                .apply();
+        Logger.debug(this, "Manual backup was created");
+        Logger.debug(this, "Receipts without backup 0");
+
     }
+
+    @Override
+    public Date getLastManualBackupDate() {
+        long millis = getSharedPreferences().getLong(Keys.USER_CREATED_MANUAL_BACKUP, 0);
+        return new Date(millis);
+    }
+
+    @Override
+    public void setOneMoreNewReceipt() {
+        if (backupProvidersManager.getSyncProvider() == SyncProvider.None) {
+            int receiptsCount = getReceiptsCountWithoutBackup();
+            getSharedPreferences().edit()
+                    .putInt(Keys.NEW_RECEIPTS_SINCE_LAST_MANUAL_BACKUP, receiptsCount + 1)
+                    .apply();
+            Logger.debug(this, "Receipts without backup " + (receiptsCount + 1));
+        }
+    }
+
+    @Override
+    public int getReceiptsCountWithoutBackup() {
+        return getSharedPreferences().getInt(Keys.NEW_RECEIPTS_SINCE_LAST_MANUAL_BACKUP, 0);
+    }
+
+    @Override
+    public void prolongReminder() {
+        int prolongationCount = getProlongationsCount();
+
+        getSharedPreferences().edit()
+                .putInt(Keys.PROLONGATION_COUNTER, prolongationCount + 1)
+                .apply();
+    }
+
+    @Override
+    public int getProlongationsCount() {
+        return getSharedPreferences().getInt(Keys.PROLONGATION_COUNTER, 0);
+    }
+
+    private SharedPreferences getSharedPreferences() {
+        return appContext.getSharedPreferences(Keys.BACKUP_TOOLTIP_PREFERENCES, Context.MODE_PRIVATE);
+    }
+
+    private void clearTrackedValues() {
+        getSharedPreferences().edit()
+                .putInt(Keys.NEW_RECEIPTS_SINCE_LAST_MANUAL_BACKUP, 0)
+                .putLong(Keys.USER_CREATED_MANUAL_BACKUP, 0L)
+                .putInt(Keys.PROLONGATION_COUNTER, 0)
+                .apply();
+    }
+
+
 }

--- a/app/src/main/java/co/smartreceipts/android/widget/tooltip/report/backup/data/BackupReminderTooltipStorage.java
+++ b/app/src/main/java/co/smartreceipts/android/widget/tooltip/report/backup/data/BackupReminderTooltipStorage.java
@@ -4,7 +4,15 @@ import java.sql.Date;
 
 public interface BackupReminderTooltipStorage {
 
-    boolean isAutomaticBackupsEnabled();
+    void setLastManualBackupDate();
 
-    Date getLastBackupDate();
+    Date getLastManualBackupDate();
+
+    void setOneMoreNewReceipt();
+
+    int getReceiptsCountWithoutBackup();
+
+    void prolongReminder();
+
+    int getProlongationsCount();
 }

--- a/app/src/main/java/co/smartreceipts/android/widget/tooltip/report/backup/data/BackupReminderTooltipStorage.java
+++ b/app/src/main/java/co/smartreceipts/android/widget/tooltip/report/backup/data/BackupReminderTooltipStorage.java
@@ -1,0 +1,10 @@
+package co.smartreceipts.android.widget.tooltip.report.backup.data;
+
+import java.sql.Date;
+
+public interface BackupReminderTooltipStorage {
+
+    boolean isAutomaticBackupsEnabled();
+
+    Date getLastBackupDate();
+}

--- a/app/src/main/java/co/smartreceipts/android/widget/tooltip/report/generate/GenerateInfoTooltipManager.java
+++ b/app/src/main/java/co/smartreceipts/android/widget/tooltip/report/generate/GenerateInfoTooltipManager.java
@@ -8,11 +8,12 @@ import co.smartreceipts.android.di.scopes.ApplicationScope;
 import co.smartreceipts.android.model.Trip;
 import co.smartreceipts.android.persistence.DatabaseHelper;
 import co.smartreceipts.android.utils.log.Logger;
+import co.smartreceipts.android.widget.tooltip.TooltipManager;
 import co.smartreceipts.android.widget.tooltip.report.generate.data.GenerateInfoTooltipStorage;
 import io.reactivex.Single;
 
 @ApplicationScope
-public class GenerateInfoTooltipManager {
+public class GenerateInfoTooltipManager implements TooltipManager{
 
     /*
     Generate info tooltip should be shown under the following conditions:
@@ -62,6 +63,7 @@ public class GenerateInfoTooltipManager {
         Logger.debug(this, "Report was generated");
     }
 
+    @Override
     public void tooltipWasDismissed() {
         preferencesStorage.tooltipWasDismissed();
         Logger.debug(this, "Generate info tooltip was dismissed");

--- a/app/src/main/res/layout/tooltip.xml
+++ b/app/src/main/res/layout/tooltip.xml
@@ -2,10 +2,10 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-                android:layout_width="match_parent"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    tools:parentTag="RelativeLayout"
-    tools:background="@color/smart_receipts_purple_light">
+    tools:background="@color/smart_receipts_purple_light"
+    tools:parentTag="RelativeLayout">
 
 
     <ImageView
@@ -14,12 +14,11 @@
         android:layout_height="wrap_content"
         android:layout_alignParentStart="true"
         android:layout_centerVertical="true"
-        android:padding="@dimen/default_margin_item_separator"
+        android:paddingStart="@dimen/default_tooltip_horizontal_padding"
         android:tint="@color/text_primary_color"
         android:visibility="gone"
-        tools:visibility="gone"
         app:srcCompat="@drawable/ic_error_outline_24dp"
-        />
+        tools:visibility="visible" />
 
     <ImageView
         android:id="@+id/tooltip_close_icon"
@@ -29,12 +28,11 @@
         android:layout_centerVertical="true"
         android:background="?attr/selectableItemBackgroundBorderless"
         android:clickable="true"
-        android:padding="@dimen/default_margin_item_separator"
+        android:paddingEnd="@dimen/default_tooltip_horizontal_padding"
         android:tint="@color/text_primary_color"
         android:visibility="gone"
-        tools:visibility="gone"
         app:srcCompat="@drawable/ic_clear_24dp"
-        />
+        tools:visibility="visible" />
 
     <Button
         android:id="@+id/tooltip_no"
@@ -45,21 +43,19 @@
         android:layout_toStartOf="@+id/tooltip_yes"
         android:text="@string/no"
         android:visibility="gone"
-        tools:visibility="visible"
-        />
+        tools:visibility="gone" />
 
     <Button
         android:id="@+id/tooltip_yes"
         style="@style/Widget.AppCompat.Button.Borderless"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
         android:layout_centerVertical="true"
         android:layout_toStartOf="@id/tooltip_close_icon"
-        android:layout_alignParentEnd="true"
         android:text="@string/yes"
         android:visibility="gone"
-        tools:visibility="visible"
-        />
+        tools:visibility="gone" />
 
     <TextView
         android:id="@+id/tooltip_message"
@@ -70,10 +66,12 @@
         android:layout_toEndOf="@id/tooltip_error_icon"
         android:layout_toStartOf="@id/tooltip_no"
         android:ellipsize="end"
-        android:padding="@dimen/default_margin_size"
-        tools:text="Like Smart Receipts?"
+        android:paddingTop="@dimen/default_tooltip_vertical_padding"
+        android:paddingBottom="@dimen/default_tooltip_vertical_padding"
+        android:paddingStart="@dimen/default_tooltip_horizontal_padding"
+        android:paddingEnd="@dimen/default_tooltip_horizontal_padding"
         android:visibility="gone"
-        tools:visibility="visible"
-        />
+        tools:text="Like Smart Receipts?"
+        tools:visibility="visible" />
 
 </RelativeLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -470,6 +470,8 @@
 
     <!-- ================== Tooltip messages ==================== -->
     <string name="tooltip_generate_info_message">Verwenden Sie den ‚Generate‘ Registerkarte um Berichte zu erstellen</string>
+    <string name="tooltip_no_backups_info_message">Erinnerung: Sichern Sie regelmäßig Ihre Daten</string>
+    <string name="tooltip_backup_info_message">%d Tage seit dein letztem Backup</string>
 
     <!-- ================== Graph titles ==================== -->
     <string name="graphs_no_data">Fügen Sie Ihre ersten Quittungen hinzu, um Graphen zu sehen.</string>
@@ -480,6 +482,5 @@
     <string name="graphs_label_reimbursable">Erstattungsfähig</string>
     <string name="graphs_label_non_reimbursable">Nicht rückzahlbar</string>
     <string name="graphs_label_others">Andere</string>
-
 
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -470,6 +470,8 @@
 
     <!-- ================== Tooltip messages ==================== -->
     <string name="tooltip_generate_info_message">Usa la pestaña \'Generar\' para crear tus informes</string>
+    <string name="tooltip_no_backups_info_message">Recordatorio: Copia periódica de sus datos</string>
+    <string name="tooltip_backup_info_message">%d días desde la última copia de seguridad</string>
 
     <!-- ================== Graph titles ==================== -->
     <string name="graphs_no_data">Agregue sus primeros recibos para ver los gráficos.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -470,6 +470,8 @@
 
     <!-- ================== Tooltip messages ==================== -->
     <string name="tooltip_generate_info_message">Utilisez l\'onglet « Générer » pour créer vos rapports</string>
+    <string name="tooltip_no_backups_info_message">Rappel: sauvegarde périodiquement vos données</string>
+    <string name="tooltip_backup_info_message">%d jours depuis votre dernière sauvegarde</string>
 
     <!-- ================== Graph titles ==================== -->
     <string name="graphs_no_data">Ajoutez vos premiers reçus pour voir les graphiques.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -470,6 +470,8 @@
 
     <!-- ================== Tooltip messages ==================== -->
     <string name="tooltip_generate_info_message">Use a aba \'Gerar\' para criar seus relatórios</string>
+    <string name="tooltip_no_backups_info_message">Lembrete: faça backup periodicamente de seus dados</string>
+    <string name="tooltip_backup_info_message">%d dias desde o último backup</string>
 
     <!-- ================== Graph titles ==================== -->
     <string name="graphs_no_data">Adicione seus primeiros recibos para ver gráficos.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -279,7 +279,7 @@
     <!-- ===================== backup menu ======================== -->
     <string name="backups">Резервные копии</string>
     <string name="manual_backup_title">Ручное резервное копирование:</string>
-    <string name="manual_backup_description">Выполняйте резервное копирование данных, чтобы обезопасить ваши чеки! Вы можете восстановить данные, импортировав файл резервной копии SmartReceipts.SMR, генерируемый нажатием кнопки \"Резервное копирование\" внизу.</string>
+    <string name="manual_backup_description">Выполняйте резервное копирование данных, чтобы обезопасить ваши чеки! Вы можете восстановить данные, импортировав файл резервной копии SmartReceipts.SMR, генерируемый нажатием кнопки \"Бэкап\" внизу.</string>
     <string name="manual_backup_export">Бэкап</string>
     <string name="manual_backup_import">Импорт</string>
     <string name="auto_backup_title">Автоматическое резервное копирование [BETA]:</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -472,6 +472,8 @@
 
     <!-- ================== Tooltip messages ==================== -->
     <string name="tooltip_generate_info_message">Используйте вкладку \"Создать\" для создания отчетов</string>
+    <string name="tooltip_no_backups_info_message">Напоминание: периодически делайте бэкап своих данных</string>
+    <string name="tooltip_backup_info_message">%d дней с момента вашего последнего бэкапа</string>
 
     <!-- ================== Graph titles ==================== -->
     <string name="graphs_no_data">Добавьте свой первый чек чтобы увидеть графики.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -472,6 +472,8 @@
 
     <!-- ================== Tooltip messages ==================== -->
     <string name="tooltip_generate_info_message">Використовуйте вкладку \"Створити\" для створення звітів</string>
+    <string name="tooltip_no_backups_info_message">Нагадування: періодично створюйте резервні копії ваших даних</string>
+    <string name="tooltip_backup_info_message">%d днів з моменту останньої резервної копії</string>
 
     <!-- ================== Graph titles ==================== -->
     <string name="graphs_no_data">Додайте свій перший чек щоб побачити графіки.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -279,7 +279,7 @@
     <!-- ===================== backup menu ======================== -->
     <string name="backups">Резервні копії</string>
     <string name="manual_backup_title">Ручне резервне копіювання:</string>
-    <string name="manual_backup_description">Виконуйте резервне копіювання даних, щоб захистити ваші чеки! Ви можете відновити дані, імпортувавши файл резервної копії SmartReceipts.SMR, що генерується натисканням кнопки \"Резервне копіювання\" внизу.</string>
+    <string name="manual_backup_description">Виконуйте резервне копіювання даних, щоб захистити ваші чеки! Ви можете відновити дані, імпортувавши файл резервної копії SmartReceipts.SMR, що генерується натисканням кнопки \"Бекап\" нижче.</string>
     <string name="manual_backup_export">Бекап</string>
     <string name="manual_backup_import">Імпорт</string>
     <string name="auto_backup_title">Автоматичне резервне копіювання [BETA]:</string>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -50,5 +50,9 @@
     <!--Graphs height-->
     <dimen name="graph_height_default">300dp</dimen>
     <dimen name="graph_height_small">130dp</dimen>
+    
+    <!--Tooltip-->
+    <dimen name="default_tooltip_horizontal_padding">8dp</dimen>
+    <dimen name="default_tooltip_vertical_padding">16dp</dimen>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -500,6 +500,8 @@
 
     <!-- ================== Tooltip messages ==================== -->
     <string name="tooltip_generate_info_message">Use the \'Generate\' tab to create your reports</string>
+    <string name="tooltip_backup_info_message">%d days since your last backup</string>
+    <string name="tooltip_no_backups_info_message">Reminder: Periodically back up your data</string>
 
     <!-- ================== Graph titles ==================== -->
     <string name="graphs_no_data">Add your first receipts to see graphs.</string>

--- a/app/src/test/java/co/smartreceipts/android/widget/tooltip/report/ReportTooltipInteractorTest.java
+++ b/app/src/test/java/co/smartreceipts/android/widget/tooltip/report/ReportTooltipInteractorTest.java
@@ -16,14 +16,18 @@ import co.smartreceipts.android.sync.BackupProvidersManager;
 import co.smartreceipts.android.sync.errors.CriticalSyncError;
 import co.smartreceipts.android.sync.errors.SyncErrorType;
 import co.smartreceipts.android.sync.provider.SyncProvider;
+import co.smartreceipts.android.widget.tooltip.report.backup.BackupReminderTooltipManager;
 import co.smartreceipts.android.widget.tooltip.report.generate.GenerateInfoTooltipManager;
+import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
-public class ReportTooltipInteractorShould {
+public class ReportTooltipInteractorTest {
+
+    private static final int DAYS = 20;
 
     //Class under test
     ReportTooltipInteractor interactor;
@@ -42,13 +46,18 @@ public class ReportTooltipInteractorShould {
     @Mock
     GenerateInfoTooltipManager generateInfoTooltipManager;
 
+    @Mock
+    BackupReminderTooltipManager backupReminderTooltipManager;
+
+
     private final SyncErrorType errorType = SyncErrorType.NoRemoteDiskSpace;
 
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
 
-        interactor = new ReportTooltipInteractor(activity, navigationHandler, backupProvidersManager, analytics, generateInfoTooltipManager);
+        interactor = new ReportTooltipInteractor(activity, navigationHandler, backupProvidersManager,
+                analytics, generateInfoTooltipManager, backupReminderTooltipManager);
 
         when(backupProvidersManager.getSyncProvider()).thenReturn(SyncProvider.GoogleDrive);
 
@@ -58,6 +67,7 @@ public class ReportTooltipInteractorShould {
     public void getErrors() throws InterruptedException {
         when(backupProvidersManager.getCriticalSyncErrorStream()).thenReturn(Observable.just(new CriticalSyncError(new Throwable(), errorType)));
         when(generateInfoTooltipManager.needToShowGenerateTooltip()).thenReturn(Single.just(false));
+        when(backupReminderTooltipManager.needToShowBackupReminder()).thenReturn(Maybe.empty());
 
         interactor.checkTooltipCauses()
                 .test()
@@ -69,6 +79,7 @@ public class ReportTooltipInteractorShould {
     public void getErrorsFirst() {
         when(backupProvidersManager.getCriticalSyncErrorStream()).thenReturn(Observable.just(new CriticalSyncError(new Throwable(), errorType)));
         when(generateInfoTooltipManager.needToShowGenerateTooltip()).thenReturn(Single.just(true));
+        when(backupReminderTooltipManager.needToShowBackupReminder()).thenReturn(Maybe.just(15));
 
         interactor.checkTooltipCauses()
                 .test()
@@ -81,6 +92,7 @@ public class ReportTooltipInteractorShould {
         //Note: with SyncProvider.GoogleDrive if there are no errors getErrorStream() returns Observable.never()
         when(backupProvidersManager.getCriticalSyncErrorStream()).thenReturn(Observable.never());
         when(generateInfoTooltipManager.needToShowGenerateTooltip()).thenReturn(Single.just(true));
+        when(backupReminderTooltipManager.needToShowBackupReminder()).thenReturn(Maybe.empty());
 
         interactor.checkTooltipCauses()
                 .test()
@@ -93,6 +105,7 @@ public class ReportTooltipInteractorShould {
         //Note: with SyncProvider.None getErrorStream() returns Observable.empty()
         when(backupProvidersManager.getCriticalSyncErrorStream()).thenReturn(Observable.empty());
         when(generateInfoTooltipManager.needToShowGenerateTooltip()).thenReturn(Single.just(true));
+        when(backupReminderTooltipManager.needToShowBackupReminder()).thenReturn(Maybe.empty());
 
         interactor.checkTooltipCauses()
                 .test()
@@ -104,6 +117,7 @@ public class ReportTooltipInteractorShould {
     public void getNoneWhenErrorsArePossible() {
         when(backupProvidersManager.getCriticalSyncErrorStream()).thenReturn(Observable.never());
         when(generateInfoTooltipManager.needToShowGenerateTooltip()).thenReturn(Single.just(false));
+        when(backupReminderTooltipManager.needToShowBackupReminder()).thenReturn(Maybe.empty());
 
         interactor.checkTooltipCauses()
                 .test()
@@ -115,10 +129,35 @@ public class ReportTooltipInteractorShould {
     public void getNoneWhenErrorsAreImpossible() {
         when(backupProvidersManager.getCriticalSyncErrorStream()).thenReturn(Observable.empty());
         when(generateInfoTooltipManager.needToShowGenerateTooltip()).thenReturn(Single.just(false));
+        when(backupReminderTooltipManager.needToShowBackupReminder()).thenReturn(Maybe.empty());
 
         interactor.checkTooltipCauses()
                 .test()
                 .assertNoErrors()
                 .assertValue(ReportTooltipUiIndicator.none());
+    }
+
+    @Test
+    public void getBackupReminder() {
+        when(backupProvidersManager.getCriticalSyncErrorStream()).thenReturn(Observable.empty());
+        when(generateInfoTooltipManager.needToShowGenerateTooltip()).thenReturn(Single.just(false));
+        when(backupReminderTooltipManager.needToShowBackupReminder()).thenReturn(Maybe.just(DAYS));
+
+        interactor.checkTooltipCauses()
+                .test()
+                .assertNoErrors()
+                .assertValue(ReportTooltipUiIndicator.backupReminder(DAYS));
+    }
+
+    @Test
+    public void getBackupReminderWhenGenerateInfoAvailable() {
+        when(backupProvidersManager.getCriticalSyncErrorStream()).thenReturn(Observable.empty());
+        when(generateInfoTooltipManager.needToShowGenerateTooltip()).thenReturn(Single.just(true));
+        when(backupReminderTooltipManager.needToShowBackupReminder()).thenReturn(Maybe.just(DAYS));
+
+        interactor.checkTooltipCauses()
+                .test()
+                .assertNoErrors()
+                .assertValue(ReportTooltipUiIndicator.backupReminder(DAYS));
     }
 }

--- a/app/src/test/java/co/smartreceipts/android/widget/tooltip/report/ReportTooltipPresenterTest.java
+++ b/app/src/test/java/co/smartreceipts/android/widget/tooltip/report/ReportTooltipPresenterTest.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.when;
 @RunWith(RobolectricTestRunner.class)
 public class ReportTooltipPresenterTest {
 
+    private static final int DAYS = 15;
+
     @InjectMocks
     ReportTooltipPresenter presenter;
 
@@ -96,5 +98,29 @@ public class ReportTooltipPresenterTest {
         verify(tooltipView).present(ReportTooltipUiIndicator.syncError(errorType));
         verify(tooltipView).present(ReportTooltipUiIndicator.none());
         verify(interactor, never()).handleClickOnErrorTooltip(errorType);
+    }
+
+    @Test
+    public void passBackupTooltipClicks() {
+        when(interactor.checkTooltipCauses()).thenReturn(Observable.just(ReportTooltipUiIndicator.backupReminder(DAYS)));
+        when(tooltipView.getTooltipsClicks()).thenReturn(Observable.just(ReportTooltipUiIndicator.backupReminder(DAYS)));
+
+        presenter.subscribe();
+
+        verify(tooltipView).present(ReportTooltipUiIndicator.backupReminder(DAYS));
+        verify(tooltipView).present(ReportTooltipUiIndicator.none());
+        verify(interactor).backupReminderTooltipClosed();
+    }
+
+    @Test
+    public void passBackupTooltipCloseClicks() {
+        when(interactor.checkTooltipCauses()).thenReturn(Observable.just(ReportTooltipUiIndicator.backupReminder(DAYS)));
+        when(tooltipView.getCloseButtonClicks()).thenReturn(Observable.just(ReportTooltipUiIndicator.backupReminder(DAYS)));
+
+        presenter.subscribe();
+
+        verify(tooltipView).present(ReportTooltipUiIndicator.backupReminder(DAYS));
+        verify(tooltipView).present(ReportTooltipUiIndicator.none());
+        verify(interactor).backupReminderTooltipClosed();
     }
 }

--- a/app/src/test/java/co/smartreceipts/android/widget/tooltip/report/ReportTooltipUiIndicatorTest.java
+++ b/app/src/test/java/co/smartreceipts/android/widget/tooltip/report/ReportTooltipUiIndicatorTest.java
@@ -9,6 +9,8 @@ import static junit.framework.Assert.assertEquals;
 
 public class ReportTooltipUiIndicatorTest {
 
+    private static final int DAYS = 5;
+
     @Test
     public void error() {
         final ReportTooltipUiIndicator indicator = ReportTooltipUiIndicator.syncError(SyncErrorType.NoRemoteDiskSpace);
@@ -25,5 +27,14 @@ public class ReportTooltipUiIndicatorTest {
         assertEquals(ReportTooltipUiIndicator.generateInfo(), indicator);
         assertEquals(State.GenerateInfo, indicator.getState());
         assertEquals(null, indicator.getErrorType().orNull());
+    }
+
+    @Test
+    public void backupReminder() {
+        final ReportTooltipUiIndicator indicator = ReportTooltipUiIndicator.backupReminder(DAYS);
+
+        assertEquals(ReportTooltipUiIndicator.backupReminder(DAYS), indicator);
+        assertEquals(State.BackupReminder, indicator.getState());
+        assertEquals(DAYS, (int)indicator.getDaysSinceBackup().get());
     }
 }

--- a/app/src/test/java/co/smartreceipts/android/widget/tooltip/report/backup/BackupReminderTooltipManagerTest.java
+++ b/app/src/test/java/co/smartreceipts/android/widget/tooltip/report/backup/BackupReminderTooltipManagerTest.java
@@ -1,0 +1,131 @@
+package co.smartreceipts.android.widget.tooltip.report.backup;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.sql.Date;
+import java.util.concurrent.TimeUnit;
+
+import co.smartreceipts.android.sync.BackupProvidersManager;
+import co.smartreceipts.android.sync.provider.SyncProvider;
+import co.smartreceipts.android.widget.tooltip.report.backup.data.BackupReminderTooltipStorage;
+
+import static org.mockito.Mockito.when;
+
+public class BackupReminderTooltipManagerTest {
+
+    private final static int RECEIPTS_FEW = 10;
+    private final static int RECEIPTS_LOT = 20;
+    private final static int DAYS_FEW = 7;
+    private final static int DAYS_LOT = 12;
+    public static final int NO_PREVIOUS_BACKUPS = -1;
+
+
+    private BackupReminderTooltipManager manager;
+
+    @Mock
+    BackupProvidersManager backupProvidersManager;
+
+    @Mock
+    BackupReminderTooltipStorage storage;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        manager = new BackupReminderTooltipManager(backupProvidersManager, storage);
+
+        when(backupProvidersManager.getSyncProvider()).thenReturn(SyncProvider.None);
+    }
+
+    @Test
+    public void getEmptyIfAutoBackupsEnabled() {
+        when(backupProvidersManager.getSyncProvider()).thenReturn(SyncProvider.GoogleDrive);
+
+        manager.needToShowBackupReminder().test()
+                .assertComplete()
+                .assertNoErrors()
+                .assertNoValues();
+    }
+
+    @Test
+    public void getEmptyIfFewReceiptsAndFewDays() {
+        when(storage.getReceiptsCountWithoutBackup()).thenReturn(RECEIPTS_FEW);
+        when(storage.getLastManualBackupDate()).thenReturn(new Date(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(DAYS_FEW)));
+
+        manager.needToShowBackupReminder().test()
+                .assertComplete()
+                .assertNoErrors()
+                .assertNoValues();
+    }
+
+    @Test
+    public void getEmptyIfFewNewReceipts() {
+        when(storage.getReceiptsCountWithoutBackup()).thenReturn(RECEIPTS_FEW);
+        when(storage.getLastManualBackupDate()).thenReturn(new Date(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(DAYS_LOT)));
+
+        manager.needToShowBackupReminder().test()
+                .assertComplete()
+                .assertNoErrors()
+                .assertNoValues();
+    }
+
+    @Test
+    public void getEmptyIfFewDays() {
+        when(storage.getReceiptsCountWithoutBackup()).thenReturn(RECEIPTS_LOT);
+        when(storage.getLastManualBackupDate()).thenReturn(new Date(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(DAYS_FEW)));
+
+        manager.needToShowBackupReminder().test()
+                .assertComplete()
+                .assertNoErrors()
+                .assertNoValues();
+    }
+
+    @Test
+    public void getDays() {
+        when(storage.getReceiptsCountWithoutBackup()).thenReturn(RECEIPTS_LOT);
+        when(storage.getLastManualBackupDate()).thenReturn(new Date(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(DAYS_LOT)));
+
+        manager.needToShowBackupReminder().test()
+                .assertComplete()
+                .assertNoErrors()
+                .assertValue(days -> days == DAYS_LOT);
+    }
+
+    @Test
+    public void getEmptyBecauseOfProlongation() {
+        when(storage.getReceiptsCountWithoutBackup()).thenReturn(RECEIPTS_LOT);
+        when(storage.getLastManualBackupDate()).thenReturn(new Date(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(DAYS_LOT)));
+        when(storage.getProlongationsCount()).thenReturn(1);
+
+        manager.needToShowBackupReminder().test()
+                .assertComplete()
+                .assertNoErrors()
+                .assertNoValues();
+    }
+
+    @Test
+    public void getDaysAfterProlongation() {
+        when(storage.getReceiptsCountWithoutBackup()).thenReturn(RECEIPTS_LOT * 2);
+        when(storage.getLastManualBackupDate()).thenReturn(new Date(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(DAYS_LOT) * 2));
+        when(storage.getProlongationsCount()).thenReturn(1);
+
+        manager.needToShowBackupReminder().test()
+                .assertComplete()
+                .assertNoErrors()
+                .assertValue(days -> days == DAYS_LOT * 2);
+    }
+
+    @Test
+    public void getMessageIfLotReceiptsAndNoDays() {
+        when(storage.getReceiptsCountWithoutBackup()).thenReturn(RECEIPTS_LOT);
+        when(storage.getLastManualBackupDate()).thenReturn(new Date(0));
+
+        manager.needToShowBackupReminder().test()
+                .assertComplete()
+                .assertNoErrors()
+                .assertValue(days -> days == NO_PREVIOUS_BACKUPS);
+    }
+}


### PR DESCRIPTION
Now we have a Backup Reminder Tooltip.

The core of its work (`BackupReminderTooltipManager`) is based on a shared preferences wrapper `BackupReminderPreferencesStorage` which allows us to track such user's actions:
* user created a new receipt
* user created manual backup
* user dismissed Backup Reminder Tooltip

 This tooltip can show two types of messages:
* `Reminder: Periodically back up your data` - if auto backups are disabled and the user has created at least 15 new receipts but we have no tracked data about his last manual backup. This situation is possible in such cases:
    - the user has never configured backups before
    - the user used auto backups but later disabled it
* `X days since your last backup` -  if auto backups are disabled, the user has created at least 15 new receipts and he has created last manual backup at least 10 days ago.

Backup Reminder is informational tooltip and its priority is lower than Drive Sync errors but higher than Generate Info message. 