### PR TITLE
PDF validation

### DIFF
--- a/app/src/main/java/co/smartreceipts/android/imports/ImageImportProcessor.java
+++ b/app/src/main/java/co/smartreceipts/android/imports/ImageImportProcessor.java
@@ -19,6 +19,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 
+import co.smartreceipts.android.imports.exceptions.InvalidImageException;
 import co.smartreceipts.android.model.Trip;
 import co.smartreceipts.android.settings.UserPreferenceManager;
 import co.smartreceipts.android.settings.catalog.UserPreference;
@@ -65,6 +66,12 @@ public class ImageImportProcessor implements FileImportProcessor {
                     final BitmapFactory.Options smallerOpts = new BitmapFactory.Options();
                     smallerOpts.inSampleSize = scale;
                     Bitmap bitmap = BitmapFactory.decodeStream(inputStream, null, smallerOpts);
+
+                    // Checking if this file is actual image
+                    if (smallerOpts.outHeight <= 0 && smallerOpts.outWidth <= 0) {
+                        emitter.onError(new InvalidImageException("Looks like selected file is not an image"));
+                        return;
+                    }
 
                     // Perform image processing
                     if (mPreferences.get(UserPreference.Camera.SaveImagesInGrayScale)) {
@@ -118,7 +125,6 @@ public class ImageImportProcessor implements FileImportProcessor {
             } finally {
                 StorageManager.closeQuietly(inputStream);
             }
-
         });
     }
 

--- a/app/src/main/java/co/smartreceipts/android/imports/exceptions/InvalidImageException.java
+++ b/app/src/main/java/co/smartreceipts/android/imports/exceptions/InvalidImageException.java
@@ -1,0 +1,10 @@
+package co.smartreceipts.android.imports.exceptions;
+
+import android.support.annotation.NonNull;
+
+public class InvalidImageException extends Exception {
+
+    public InvalidImageException(@NonNull String message) {
+        super(message);
+    }
+}

--- a/app/src/main/java/co/smartreceipts/android/imports/exceptions/InvalidPdfException.java
+++ b/app/src/main/java/co/smartreceipts/android/imports/exceptions/InvalidPdfException.java
@@ -1,0 +1,10 @@
+package co.smartreceipts.android.imports.exceptions;
+
+import android.support.annotation.NonNull;
+
+public class InvalidPdfException extends Exception {
+
+    public InvalidPdfException(@NonNull String message) {
+        super(message);
+    }
+}

--- a/app/src/main/java/co/smartreceipts/android/imports/intents/widget/info/IntentImportInformationInteractor.java
+++ b/app/src/main/java/co/smartreceipts/android/imports/intents/widget/info/IntentImportInformationInteractor.java
@@ -16,7 +16,7 @@ import co.smartreceipts.android.imports.intents.model.IntentImportResult;
 import co.smartreceipts.android.permissions.ActivityPermissionsRequester;
 import co.smartreceipts.android.permissions.PermissionRequester;
 import co.smartreceipts.android.permissions.PermissionStatusChecker;
-import co.smartreceipts.android.permissions.PermissionsNotGrantedException;
+import co.smartreceipts.android.permissions.exceptions.PermissionsNotGrantedException;
 import co.smartreceipts.android.widget.model.UiIndicator;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;

--- a/app/src/main/java/co/smartreceipts/android/imports/utils/PdfValidator.java
+++ b/app/src/main/java/co/smartreceipts/android/imports/utils/PdfValidator.java
@@ -11,6 +11,7 @@ import org.apache.commons.io.IOUtils;
 import java.io.File;
 import java.io.IOException;
 
+import co.smartreceipts.android.utils.log.Logger;
 import co.smartreceipts.android.workers.reports.pdf.renderer.imagex.PdfPDImageXFactory;
 import co.smartreceipts.android.workers.reports.pdf.renderer.imagex.PdfPDImageXFactoryFactory;
 
@@ -29,7 +30,7 @@ public class PdfValidator {
             // document has at least one page == it's valid
             return factory.nextPage();
         } catch (IOException e) {
-            e.printStackTrace();
+            Logger.error(this, "Invalid PDF File", e);
             return false;
         }  finally {
             IOUtils.closeQuietly(factory);

--- a/app/src/main/java/co/smartreceipts/android/imports/utils/PdfValidator.java
+++ b/app/src/main/java/co/smartreceipts/android/imports/utils/PdfValidator.java
@@ -1,0 +1,38 @@
+package co.smartreceipts.android.imports.utils;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import com.google.common.base.Preconditions;
+import com.tom_roush.pdfbox.pdmodel.PDDocument;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+import co.smartreceipts.android.workers.reports.pdf.renderer.imagex.PdfPDImageXFactory;
+import co.smartreceipts.android.workers.reports.pdf.renderer.imagex.PdfPDImageXFactoryFactory;
+
+public class PdfValidator {
+
+    private final Context context;
+
+    public PdfValidator(@NonNull Context context) {
+        this.context = Preconditions.checkNotNull(context);
+    }
+
+    public boolean isPdfValid(@NonNull File file) {
+        PdfPDImageXFactory factory = new PdfPDImageXFactoryFactory(context, new PDDocument(), file).get();
+        try {
+            factory.open();
+            // document has at least one page == it's valid
+            return factory.nextPage();
+        } catch (IOException e) {
+            e.printStackTrace();
+            return false;
+        }  finally {
+            IOUtils.closeQuietly(factory);
+        }
+    }
+}

--- a/app/src/main/java/co/smartreceipts/android/permissions/PermissionsDelegate.java
+++ b/app/src/main/java/co/smartreceipts/android/permissions/PermissionsDelegate.java
@@ -1,0 +1,41 @@
+package co.smartreceipts.android.permissions;
+
+import android.support.annotation.NonNull;
+
+import javax.inject.Inject;
+
+import co.smartreceipts.android.activities.SmartReceiptsActivity;
+import co.smartreceipts.android.di.scopes.ActivityScope;
+import co.smartreceipts.android.permissions.exceptions.PermissionsNotGrantedException;
+import io.reactivex.Completable;
+
+@ActivityScope
+public class PermissionsDelegate {
+
+    @Inject
+    PermissionStatusChecker permissionStatusChecker;
+    @Inject
+    ActivityPermissionsRequester<SmartReceiptsActivity> permissionRequester;
+
+    @Inject
+    public PermissionsDelegate() {
+    }
+
+    public Completable checkPermissionAndMaybeAsk(@NonNull String manifestPermission) {
+        return permissionStatusChecker.isPermissionGranted(manifestPermission)
+                .flatMapCompletable(isGranted -> {
+                    if (isGranted) {
+                        return Completable.complete();
+                    } else {
+                        return permissionRequester.request(manifestPermission)
+                                .flatMapCompletable(permissionResponse -> {
+                                    if (permissionResponse.wasGranted()) {
+                                        return Completable.complete();
+                                    } else {
+                                        return Completable.error(new PermissionsNotGrantedException("User failed to grant permission", manifestPermission));
+                                    }
+                                });
+                    }
+                });
+    }
+}

--- a/app/src/main/java/co/smartreceipts/android/permissions/exceptions/PermissionsNotGrantedException.java
+++ b/app/src/main/java/co/smartreceipts/android/permissions/exceptions/PermissionsNotGrantedException.java
@@ -1,4 +1,4 @@
-package co.smartreceipts.android.permissions;
+package co.smartreceipts.android.permissions.exceptions;
 
 import android.support.annotation.NonNull;
 

--- a/app/src/main/java/co/smartreceipts/android/receipts/ReceiptsListFragment.java
+++ b/app/src/main/java/co/smartreceipts/android/receipts/ReceiptsListFragment.java
@@ -1,6 +1,5 @@
 package co.smartreceipts.android.receipts;
 
-import android.Manifest;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
@@ -304,21 +303,8 @@ public class ReceiptsListFragment extends ReceiptsFragment implements ReceiptTab
     }
 
     private void importReceipt() {
-        permissionsDelegate.checkPermissionAndMaybeAsk(Manifest.permission.READ_EXTERNAL_STORAGE)
-                .subscribe(() -> {
-                            try {
-                                final ImportPhotoPdfDialogFragment fragment = new ImportPhotoPdfDialogFragment();
-                                fragment.show(getChildFragmentManager(), ImportPhotoPdfDialogFragment.TAG);
-                            } catch (IllegalStateException ex) { // This exception is always thrown if saveInstanceState was already been called.
-                                // hack to not force the user to open import dialog manually again after he gave us needed permission
-                                floatingActionMenu.post(() -> {
-                                    floatingActionMenu.open(true);
-                                    final ImportPhotoPdfDialogFragment fragment = new ImportPhotoPdfDialogFragment();
-                                    fragment.show(getChildFragmentManager(), ImportPhotoPdfDialogFragment.TAG);
-                                });
-                            }
-                        },
-                        throwable -> Toast.makeText(getContext(), getString(R.string.toast_no_storage_permissions), Toast.LENGTH_SHORT).show());
+        final ImportPhotoPdfDialogFragment fragment = new ImportPhotoPdfDialogFragment();
+        fragment.show(getChildFragmentManager(), ImportPhotoPdfDialogFragment.TAG);
     }
 
     public final boolean showReceiptMenu(final Receipt receipt) {

--- a/app/src/main/java/co/smartreceipts/android/utils/UriUtils.java
+++ b/app/src/main/java/co/smartreceipts/android/utils/UriUtils.java
@@ -10,8 +10,6 @@ import android.webkit.MimeTypeMap;
 
 import java.io.File;
 
-import wb.android.storage.StorageManager;
-
 public class UriUtils {
 
     private UriUtils() {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -171,6 +171,7 @@
     <string name="database_get_error">Fehler: Fehler beim Holen  Ihrer Daten. Versuchen Sie die App. neu zu starten.</string>
     <string name="IMG_OPEN_ERROR">Fehler: Das Bild ist derzeit nicht zugänglich oder beschädigt. SD-Karte ist nicht verfügbar oder am Computer montiert. Wenn nicht, klicken Sie auf die Menü-Taste, um das Foto wieder zu holen.</string>
     <string name="IMG_SAVE_ERROR">Fehler: Das Bild konnte nicht richtig gespeichert werden</string>
+    <string name="FILE_SAVE_ERROR">Fehler: Die Datei konnte nicht korrekt gespeichert werden</string>
     <string name="ILLEGAL_CHAR_ERROR">Fehler: Der Name enthält ein unzulässiges Zeichen</string>
     <string name="SPACE_ERROR">Fehler: Der Name kann nicht mit einem Leerzeichen beginnen,</string>
     <string name="CALENDAR_TAB_ERROR">Fehler: Bitte Tippen Sie auf die Datum TextBox, um das Datum einzustellen</string>
@@ -191,6 +192,7 @@
     <string name="toast_receipt_pdf_added">Neue PDF erfolgreich auf %s hinzugefügt</string>
     <string name="toast_receipt_pdf_replaced">Eine neue PDF für %s wurde erfolgreich ersetzt</string>
     <string name="toast_import_complete">Alle Dateien wurden erfolgreich importiert. Bitte starten Sie die App. erneut</string>
+    <string name="toast_no_storage_permissions">Kann keine Datei ohne Speicherberechtigungen importieren</string>
 
     <!-- ================== Trip Adapter ===================== -->
     <string name="trip_adapter_list_item_to"> nach</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -171,6 +171,7 @@
     <string name="database_get_error">Error: No se pudo obtener tu información. Intenta reiniciar la app.</string>
     <string name="IMG_OPEN_ERROR">Error: La imagen actualmente es inaccesible o está dañada. Tu tarjeta SD puede no estar disponible o estar montada en el computador. Si no lo está, haz clic en el botón menú para tomar de nuevo la foto.</string>
     <string name="IMG_SAVE_ERROR">Error: La imagen no se pudo guardar correctamente</string>
+    <string name="FILE_SAVE_ERROR">Error: El archivo no se pudo guardar correctamente.</string>
     <string name="ILLEGAL_CHAR_ERROR">Error: El nombre contiene un carácter ilegal</string>
     <string name="SPACE_ERROR">Error: El nombre no puede comenzar con un espacio</string>
     <string name="CALENDAR_TAB_ERROR">Error: Por favor toca la caja de texto de fecha para definir la fecha</string>
@@ -191,6 +192,7 @@
     <string name="toast_receipt_pdf_added">Se añadió correctamente un PDF nuevo a %s</string>
     <string name="toast_receipt_pdf_replaced">Se reemplazó correctamente un PDF nuevo de %s</string>
     <string name="toast_import_complete">Se importaron correctamente todos los archivos. Por favor reinicia la app.</string>
+    <string name="toast_no_storage_permissions">No se puede importar archivos sin permisos de almacenamiento</string>
 
     <!-- ================== Trip Adapter ===================== -->
     <string name="trip_adapter_list_item_to">hasta</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -171,6 +171,7 @@
     <string name="database_get_error">Erreur : Échec de la récupération de vos données. Essayez de relancer l\'appli.</string>
     <string name="IMG_OPEN_ERROR">Erreur : L’image est actuellement inaccessible ou corrompue. Votre carte SD peut être indisponible ou montée sur votre ordinateur. Si ce n’est pas le cas, cliquez sur le bouton du menu pour reprendre la photo.</string>
     <string name="IMG_SAVE_ERROR">Erreur : L’image n’a pas été enregistrée correctement</string>
+    <string name="FILE_SAVE_ERROR">Erreur: Le fichier n’a pas pu être enregistré correctement.</string>
     <string name="ILLEGAL_CHAR_ERROR">Erreur : Le nom contient un caractère illégal</string>
     <string name="SPACE_ERROR">Erreur : Le nom ne peut pas commencer par un espace</string>
     <string name="CALENDAR_TAB_ERROR">Erreur : Veuillez toucher la zone de texte de la date pour définir la date</string>
@@ -191,6 +192,7 @@
     <string name="toast_receipt_pdf_added">Vous avez joint un nouveau PDF à %s</string>
     <string name="toast_receipt_pdf_replaced">Vous avez remplacé un nouveau PDF pour %s</string>
     <string name="toast_import_complete">Importation réussie de tous les fichiers. Veuillez relancer l\'appli.</string>
+    <string name="toast_no_storage_permissions">Impossible d\'importer des fichiers sans autorisation de stockage</string>
 
     <!-- ================== Trip Adapter ===================== -->
     <string name="trip_adapter_list_item_to"> à</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -171,6 +171,7 @@
     <string name="database_get_error">Erro: Falha ao obter dados. Tente reinicializar o app.</string>
     <string name="IMG_OPEN_ERROR">Erro: A imagem está inacessível ou corrompida. Seu cartão SD pode estar indisponível ou instalado em seu computador. Se esse não for o caso, clique no botão do menu para tirar a foto novamente</string>
     <string name="IMG_SAVE_ERROR">Erro: Falha ao salvar imagem</string>
+    <string name="FILE_SAVE_ERROR">Erro: Falha ao salvar arquivo</string>
     <string name="ILLEGAL_CHAR_ERROR">Erro: O nome contém um caractere inválido</string>
     <string name="SPACE_ERROR">Erro: O nome não pode começar com um espaço</string>
     <string name="CALENDAR_TAB_ERROR">Erro: Toque na Caixa de texto \'Data\' para definir a data</string>
@@ -191,6 +192,7 @@
     <string name="toast_receipt_pdf_added">Novo PDF adicionado a %s com êxito</string>
     <string name="toast_receipt_pdf_replaced">Novo PDF substituído por %s com êxito</string>
     <string name="toast_import_complete">Arquivos importados com êxito. Reinicialize o app.</string>
+    <string name="toast_no_storage_permissions">Não é possível importar arquivos sem permissões de armazenamento</string>
 
     <!-- ================== Trip Adapter ===================== -->
     <string name="trip_adapter_list_item_to">para</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -173,6 +173,7 @@
     <string name="database_get_error">Ошибка: Не удалось получить данные. Попробуйте перезапустить приложение.</string>
     <string name="IMG_OPEN_ERROR">Ошибка: Изображение в настоящее время недоступно или повреждено. Ваша SD-карта может быть недоступна или подключена к вашему компьютеру. Если это не так, нажмите кнопку меню, чтобы сделать снимок еще раз.</string>
     <string name="IMG_SAVE_ERROR">Ошибка: Не удалось сохранить изображение должным образом</string>
+    <string name="FILE_SAVE_ERROR">Ошибка: Не удалось сохранить файл должным образом</string>
     <string name="ILLEGAL_CHAR_ERROR">Ошибка: Имя содержит недопустимый символ</string>
     <string name="SPACE_ERROR">Ошибка: Имя не может начинаться с пробела</string>
     <string name="CALENDAR_TAB_ERROR">Ошибка: Пожалуйста, нажмите на поле даты для установки даты</string>
@@ -193,6 +194,7 @@
     <string name="toast_receipt_pdf_added">Новый PDF успешно добавлен в %s</string>
     <string name="toast_receipt_pdf_replaced">Успешно заменен PDF в %s</string>
     <string name="toast_import_complete">Все файлы успешно импортированы. Пожалуйста, перезапустите приложение.</string>
+    <string name="toast_no_storage_permissions">Невозможно импортировать файл без разрешения на чтение</string>
 
     <!-- ================== Trip Adapter ===================== -->
     <string name="trip_adapter_list_item_to">\u0020до\u0020</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -173,6 +173,7 @@
     <string name="database_get_error">Помилка: Не вдалося завантажити дані. Спробуйте перезапустити додаток.</string>
     <string name="IMG_OPEN_ERROR">Помилка: Зображення на даний час недоступно або пошкоджено. Ваша SD-карта може бути недоступна або підключена до вашого комп\'ютера. Якщо це не так, натисніть кнопку меню, щоб зробити знімок ще раз.</string>
     <string name="IMG_SAVE_ERROR">Помилка: Не вдалося зберегти зображення належним чином</string>
+    <string name="FILE_SAVE_ERROR">Помилка: Не вдалося зберегти файл належним чином</string>
     <string name="ILLEGAL_CHAR_ERROR">Помилка: Ім\'я містить неприпустимий символ</string>
     <string name="SPACE_ERROR">Помилка: Ім\'я не може починатися з пробілу</string>
     <string name="CALENDAR_TAB_ERROR">Помилка: Будь ласка, натисніть на поле дати для установки дати</string>
@@ -193,6 +194,7 @@
     <string name="toast_receipt_pdf_added">Новий PDF вдало доданий в %s</string>
     <string name="toast_receipt_pdf_replaced">Вдало замінений PDF в %s</string>
     <string name="toast_import_complete">Всі файли вдало імпортовані. Будь ласка, перезапустіть додаток.</string>
+    <string name="toast_no_storage_permissions">Неможливо імпортувати файл без дозволу на читання</string>
 
     <!-- ================== Trip Adapter ===================== -->
     <string name="trip_adapter_list_item_to">\u0020до\u0020</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -176,6 +176,7 @@
     <string name="database_get_error">Error: Failed to fetch your data. Try re-launching the app.</string>
     <string name="IMG_OPEN_ERROR">Error: The image is currently inaccessible or corrupted. Your SD Card may be unavailable or mounted to your computer. If not, click the menu button to retake the photo.</string>
     <string name="IMG_SAVE_ERROR">Error: The Image Failed to Save Properly</string>
+    <string name="FILE_SAVE_ERROR">Error: The File Failed to Save Properly</string>
     <string name="ILLEGAL_CHAR_ERROR">Error: The name contains an illegal character</string>
     <string name="SPACE_ERROR">Error: The name cannot begin with a space</string>
     <string name="CALENDAR_TAB_ERROR">Error: Please Touch the Date TextBox to set the Date</string>
@@ -195,7 +196,7 @@
     <string name="toast_receipt_image_replaced">Successfully replaced a new image for %s</string>
     <string name="toast_receipt_pdf_added">Successfully added a new PDF to %s</string>
     <string name="toast_receipt_pdf_replaced">Successfully replaced a new PDF for %s</string>
-    <string name="toast_no_storage_permissions">Cannot import this file without storage permissions</string>
+    <string name="toast_no_storage_permissions">Cannot import file without storage permissions</string>
     <string name="toast_import_complete">Successfully imported all files. Please re-launch the app.</string>
 
     <!-- ================== Trip Adapter ===================== -->

--- a/app/src/test/java/co/smartreceipts/android/imports/intents/widget/info/IntentImportInformationInteractorTest.java
+++ b/app/src/test/java/co/smartreceipts/android/imports/intents/widget/info/IntentImportInformationInteractorTest.java
@@ -19,7 +19,7 @@ import co.smartreceipts.android.imports.intents.model.IntentImportResult;
 import co.smartreceipts.android.permissions.ActivityPermissionsRequester;
 import co.smartreceipts.android.permissions.PermissionAuthorizationResponse;
 import co.smartreceipts.android.permissions.PermissionStatusChecker;
-import co.smartreceipts.android.permissions.PermissionsNotGrantedException;
+import co.smartreceipts.android.permissions.exceptions.PermissionsNotGrantedException;
 import co.smartreceipts.android.widget.model.UiIndicator;
 import io.reactivex.Maybe;
 import io.reactivex.Single;


### PR DESCRIPTION
I've added a small check for image import (directly in `ImageImportProcessor.process` body) and `PdfValidator` class which allows us to check if the pdf file can be read. 

Actually, "wrong" image file (for ex which is a text file in fact) couldn't be imported even without this changes, but now we have a special `InvalidImageException` for this case.

All import operations need `READ_EXTERNAL_STORAGE` permission, but we had no this check before and import process failed with a general error message but without any explanations for the user. So I've added permission check when the user clicks on the `Import` button. If we have no `READ_EXTERNAL_STORAGE` permission, the app will ask the user to give it. If he declines our request we will show him toast with `"Cannot import file without storage permissions"` message. 
One strange note: we had a string with such toast message but it wasn't used and wasn't translated...

For permission checking, I've added `PermissionsDelegate` class which actually just combines work of  `PermissionStatusChecker` and `PermissionRequester` and returns simple `Completable`. Pretty сonvenient tool to use I think :)

And about testing. I really tried to test not valid files but it's some sort of pain. For example, when Roboelectric tries to read image file which is not actually an image, roughly speaking
 I expect to get -1 values of image's width and height (like real Android does) or even 0, but I get 100 because of `ShadowBitmapFactory` internal work   ¯ \ _ (ツ) _ / ¯