### PR TITLE
Update receipt item card to constraint layout

### DIFF
--- a/app/src/main/res/layout/item_receipt_card.xml
+++ b/app/src/main/res/layout/item_receipt_card.xml
@@ -1,114 +1,115 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginBottom="@dimen/margin_tiniest"
     android:layout_marginEnd="@dimen/margin_tiny"
     android:layout_marginStart="@dimen/margin_tiny"
-    android:clickable="true"
-    android:foreground="?attr/selectableItemBackground"
-    android:orientation="vertical">
+    android:layout_marginTop="@dimen/margin_tiniest"
+    android:background="@color/selected_card_background"
+    app:cardCornerRadius="@dimen/card_corner_radius">
 
-    <android.support.v7.widget.CardView
+    <android.support.constraint.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@color/selected_card_background"
-        android:layout_marginBottom="@dimen/margin_tiniest"
-        android:layout_marginTop="@dimen/margin_tiniest"
-        app:cardCornerRadius="@dimen/card_corner_radius">
+        android:layout_height="wrap_content">
 
-        <RelativeLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+        <ImageView
+            android:id="@+id/card_menu"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:clickable="true"
+            android:padding="@dimen/padding_small"
+            android:src="@drawable/ic_menu_24dp"
+            android:tint="@color/text_secondary_color"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:ignore="ContentDescription" />
 
-            <ImageView
-                android:id="@+id/card_image"
-                android:layout_width="@dimen/card_image_size"
-                android:layout_height="@dimen/card_image_size"
-                android:layout_alignParentStart="true"
-                android:layout_alignParentTop="true"
-                android:layout_below="@id/divider"
-                android:layout_marginEnd="@dimen/margin_tiny"
-                android:background="@color/card_image_background"
-                android:clickable="true"
-                android:foreground="?attr/selectableItemBackground"
-                android:padding="@dimen/padding_normal"
-                tools:src="@drawable/ic_file_black_24dp"
-                tools:tint="@color/card_image_tint" />
+        <ImageView
+            android:id="@+id/card_sync_state"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/margin_tiny"
+            android:layout_marginStart="@dimen/margin_tiny"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:clickable="true"
+            android:padding="@dimen/padding_small"
+            android:tint="@color/text_secondary_color"
+            app:layout_constraintEnd_toStartOf="@id/card_menu"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:src="@drawable/ic_cloud_done_24dp"
+            tools:ignore="ContentDescription" />
 
-            <TextView
-                android:id="@android:id/title"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_tiny"
-                android:layout_toEndOf="@id/card_image"
-                android:layout_toStartOf="@id/card_sync_state"
-                android:ellipsize="end"
-                android:maxLines="1"
-                android:textColor="@color/text_primary_color"
-                android:textSize="@dimen/font_subhead"
-                tools:text="Title" />
+        <TextView
+            android:id="@android:id/title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/margin_tiny"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="@color/text_primary_color"
+            android:textSize="@dimen/font_subhead"
+            app:layout_constraintEnd_toStartOf="@+id/card_sync_state"
+            app:layout_constraintStart_toEndOf="@id/card_image"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Title" />
 
-            <TextView
-                android:id="@+id/price"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignBottom="@id/card_image"
-                android:layout_marginBottom="@dimen/margin_tiny"
-                android:layout_marginEnd="@dimen/margin_tiny"
-                android:layout_toEndOf="@+id/card_image"
-                android:layout_toStartOf="@+id/card_category"
-                android:ellipsize="end"
-                android:maxLines="1"
-                android:textColor="@color/text_primary_color"
-                android:textSize="@dimen/font_headline"
-                tools:text="20$" />
+        <TextView
+            android:id="@+id/price"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/margin_tiny"
+            android:layout_toStartOf="@+id/card_category"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="@color/text_primary_color"
+            android:textSize="@dimen/font_headline"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/card_category"
+            app:layout_constraintStart_toEndOf="@id/card_image"
+            app:layout_constraintTop_toBottomOf="@android:id/title"
+            tools:text="20$" />
 
-            <ImageView
-                android:id="@+id/card_menu"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
-                android:layout_centerHorizontal="true"
-                android:background="?attr/selectableItemBackgroundBorderless"
-                android:clickable="true"
-                android:padding="@dimen/padding_small"
-                android:src="@drawable/ic_menu_24dp"
-                android:tint="@color/text_secondary_color" />
 
-            <ImageView
-                android:id="@+id/card_sync_state"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentTop="true"
-                android:layout_marginEnd="@dimen/margin_tiny"
-                android:layout_marginStart="@dimen/margin_tiny"
-                android:layout_toStartOf="@id/card_menu"
-                android:background="?attr/selectableItemBackgroundBorderless"
-                android:clickable="true"
-                android:padding="@dimen/padding_small"
-                android:tint="@color/text_secondary_color"
-                tools:src="@drawable/ic_cloud_done_24dp" />
+        <TextView
+            android:id="@+id/card_category"
+            android:layout_width="wrap_content"
+            android:layout_height="0dp"
+            android:layout_marginBottom="@dimen/margin_tiny"
+            android:layout_marginEnd="@dimen/margin_tiny"
+            android:layout_marginTop="@dimen/margin_tiny"
+            android:ellipsize="end"
+            android:gravity="bottom"
+            android:lines="1"
+            android:maxWidth="70dp"
+            android:textColor="@color/text_primary_color"
+            android:textSize="@dimen/font_caption"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/card_menu"
+            tools:text="category long long name"
+            tools:visibility="visible" />
 
-            <TextView
-                android:id="@+id/card_category"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignBottom="@+id/price"
-                android:layout_alignParentEnd="true"
-                android:layout_marginEnd="@dimen/margin_tiny"
-                android:ellipsize="end"
-                android:lines="1"
-                android:maxWidth="100dp"
-                android:textColor="@color/text_primary_color"
-                android:textSize="@dimen/font_caption"
-                android:visibility="gone"
-                tools:text="category long name"
-                tools:visibility="visible" />
+        <ImageView
+            android:id="@+id/card_image"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@color/card_image_background"
+            android:clickable="true"
+            android:foreground="?attr/selectableItemBackground"
+            android:padding="@dimen/padding_normal"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:src="@drawable/ic_file_black_24dp"
+            tools:tint="@color/card_image_tint"
+            tools:ignore="ContentDescription" />
 
-        </RelativeLayout>
 
-    </android.support.v7.widget.CardView>
-
-</LinearLayout>
+    </android.support.constraint.ConstraintLayout>
+</android.support.v7.widget.CardView>


### PR DESCRIPTION
I wasn't able to reproduce a bug with "large" text overlapping, but this changes will fix it. So, now `item_receipt_card` is based on `ConstraintLayout`.