### PR TITLE
Improved zip reports

### DIFF
--- a/app/src/main/java/co/smartreceipts/android/analytics/events/Events.java
+++ b/app/src/main/java/co/smartreceipts/android/analytics/events/Events.java
@@ -65,7 +65,8 @@ public final class Events {
         public static final Event FullPdfReport = new DefaultEvent(Category.Generate, "FullPdfReport");
         public static final Event ImagesPdfReport = new DefaultEvent(Category.Generate, "ImagesPdfReport");
         public static final Event CsvReport = new DefaultEvent(Category.Generate, "CsvReport");
-        public static final Event StampedZipReport = new DefaultEvent(Category.Generate, "StampedZipReport");
+        public static final Event ZipWithMetadataReport = new DefaultEvent(Category.Generate, "ZipWithMetadataReport");
+        public static final Event ZipReport = new DefaultEvent(Category.Generate, "ZipReport");
         public static final Event ReportPdfRenderingError = new DefaultEvent(Category.Generate, "ReportPdfRenderingError");
     }
 

--- a/app/src/main/java/co/smartreceipts/android/receipts/ReceiptsAdapter.java
+++ b/app/src/main/java/co/smartreceipts/android/receipts/ReceiptsAdapter.java
@@ -17,6 +17,7 @@ import com.squareup.picasso.Picasso;
 
 import java.sql.Date;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -160,6 +161,8 @@ public class ReceiptsAdapter extends DraggableCardsAdapter<Receipt> implements R
 
             updatedItems.add(updatedReceipt);
         }
+
+        Collections.sort(updatedItems);
 
         items.clear();
         items.addAll(updatedItems);

--- a/app/src/main/java/co/smartreceipts/android/receipts/ReceiptsAdapter.java
+++ b/app/src/main/java/co/smartreceipts/android/receipts/ReceiptsAdapter.java
@@ -117,7 +117,8 @@ public class ReceiptsAdapter extends DraggableCardsAdapter<Receipt> implements R
 
         Logger.debug(this, "Moving receipt from position {} to position {}", realFromPosition, realToPosition);
 
-        if (!orderingPreferencesManager.isReceiptsTableOrdered()) setDefaultOrderIds();
+        if (!orderingPreferencesManager.isReceiptsTableOrdered() || !isThisTripOrdered())
+            setDefaultOrderIds();
 
         if (isOldCustomOrderIdFormatUsed()) {
             setDefaultOrderIds();
@@ -189,6 +190,15 @@ public class ReceiptsAdapter extends DraggableCardsAdapter<Receipt> implements R
         }
 
         return false;
+    }
+
+    private boolean isThisTripOrdered() {
+        for (Receipt item : items) {
+            if (item.getCustomOrderId() == 0) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private void writeUpdatedItems(List<Receipt> receipts) {

--- a/app/src/main/java/co/smartreceipts/android/workers/EmailAssistant.java
+++ b/app/src/main/java/co/smartreceipts/android/workers/EmailAssistant.java
@@ -88,7 +88,7 @@ public class EmailAssistant {
     private final Trip trip;
     private final PurchaseWallet purchaseWallet;
 
-    public static final Intent getEmailDeveloperIntent() {
+    private static Intent getEmailDeveloperIntent() {
         Intent intent = new Intent(Intent.ACTION_SENDTO);
         intent.setType("text/plain");
         setEmailDeveloperRecipient(intent);
@@ -100,20 +100,20 @@ public class EmailAssistant {
         intent.setData(Uri.parse("mailto:" + DEVELOPER_EMAIL));
     }
 
-    public static final Intent getEmailDeveloperIntent(String subject) {
+    public static Intent getEmailDeveloperIntent(String subject) {
         Intent intent = getEmailDeveloperIntent();
         intent.putExtra(Intent.EXTRA_SUBJECT, subject);
         return intent;
     }
 
 
-    public static final Intent getEmailDeveloperIntent(String subject, String body) {
+    public static Intent getEmailDeveloperIntent(String subject, String body) {
         Intent intent = getEmailDeveloperIntent(subject);
         intent.putExtra(Intent.EXTRA_TEXT, body);
         return intent;
     }
 
-    public static final Intent getEmailDeveloperIntent(Context context, String subject, String body, List<File> files) {
+    public static Intent getEmailDeveloperIntent(Context context, String subject, String body, List<File> files) {
         Intent intent = IntentUtils.getSendIntent(context, files);
         intent.putExtra(Intent.EXTRA_EMAIL, new String[]{DEVELOPER_EMAIL});
         intent.putExtra(Intent.EXTRA_SUBJECT, subject);
@@ -138,7 +138,7 @@ public class EmailAssistant {
         attachmentWriter.execute(trip);
     }
 
-    public void onAttachmentsCreated(File[] attachments) {
+    private void onAttachmentsCreated(File[] attachments) {
         List<File> files = new ArrayList<>();
         StringBuilder bodyBuilder = new StringBuilder();
         String path = "";
@@ -225,7 +225,7 @@ public class EmailAssistant {
         public boolean didZIPFailCompletely = false;
         public boolean didZIPFailPartially = false;
 
-        public static final WriterResults getFullFailureInstance() {
+        public static WriterResults getFullFailureInstance() {
             WriterResults result = new WriterResults();
             result.didPDFFailCompletely = true;
             result.didPDFFailPartially = true;

--- a/app/src/main/java/co/smartreceipts/android/workers/EmailAssistant.java
+++ b/app/src/main/java/co/smartreceipts/android/workers/EmailAssistant.java
@@ -68,7 +68,8 @@ public class EmailAssistant {
         PDF_FULL(0),
         PDF_IMAGES_ONLY(1),
         CSV(2),
-        ZIP_IMAGES_STAMPED(3);
+        ZIP(3),
+        ZIP_WITH_METADATA(4);
 
         private final int index;
 
@@ -166,12 +167,12 @@ public class EmailAssistant {
                 bodyBuilder.append(context.getString(R.string.email_body_subject_5mb_warning, attachments[EmailOptions.CSV.getIndex()].getAbsolutePath()));
             }
         }
-        if (attachments[EmailOptions.ZIP_IMAGES_STAMPED.getIndex()] != null) {
-            path = attachments[EmailOptions.ZIP_IMAGES_STAMPED.getIndex()].getParentFile().getAbsolutePath();
-            files.add(attachments[EmailOptions.ZIP_IMAGES_STAMPED.getIndex()]);
-            if (attachments[EmailOptions.ZIP_IMAGES_STAMPED.getIndex()].length() > 5000000) { //Technically, this should be 5,242,880 but I'd rather give a warning buffer
+        if (attachments[EmailOptions.ZIP_WITH_METADATA.getIndex()] != null) {
+            path = attachments[EmailOptions.ZIP_WITH_METADATA.getIndex()].getParentFile().getAbsolutePath();
+            files.add(attachments[EmailOptions.ZIP_WITH_METADATA.getIndex()]);
+            if (attachments[EmailOptions.ZIP_WITH_METADATA.getIndex()].length() > 5000000) { //Technically, this should be 5,242,880 but I'd rather give a warning buffer
                 bodyBuilder.append("\n");
-                bodyBuilder.append(context.getString(R.string.email_body_subject_5mb_warning, attachments[EmailOptions.ZIP_IMAGES_STAMPED.getIndex()].getAbsolutePath()));
+                bodyBuilder.append(context.getString(R.string.email_body_subject_5mb_warning, attachments[EmailOptions.ZIP_WITH_METADATA.getIndex()].getAbsolutePath()));
             }
         }
         Logger.info(this, "Built the following files [{}].", files);
@@ -258,7 +259,7 @@ public class EmailAssistant {
             mPreferenceManager = persistenceManager.getPreferenceManager();
             mProgressDialog = new WeakReference<>(dialog);
             mOptions = options;
-            mFiles = new File[]{null, null, null, null};
+            mFiles = new File[]{null, null, null, null, null};
             memoryErrorOccured = false;
         }
 
@@ -377,10 +378,14 @@ public class EmailAssistant {
                     results.didCSVFailCompletely = true;
                 }
             }
-            if (mOptions.contains(EmailOptions.ZIP_IMAGES_STAMPED)) {
+            if (mOptions.contains(EmailOptions.ZIP)) {
+                // TODO: 20.04.2018 add new zip
+            }
+            if (mOptions.contains(EmailOptions.ZIP_WITH_METADATA)) {
                 mStorageManager.delete(dir, dir.getName() + ".zip");
                 dir = mStorageManager.mkdir(trip.getDirectory(), trip.getName());
                 for (int i = 0; i < len; i++) {
+                    // TODO: 20.04.2018
                     if (!filterOutReceipt(mPreferenceManager, receipts.get(i)) && receipts.get(i).hasImage()) {
                         try {
                             Bitmap b = stampImage(trip, receipts.get(i), Bitmap.Config.ARGB_8888);
@@ -409,7 +414,7 @@ public class EmailAssistant {
                 }
                 File zip = mStorageManager.zipBuffered(dir, 2048);
                 mStorageManager.deleteRecursively(dir);
-                mFiles[EmailOptions.ZIP_IMAGES_STAMPED.getIndex()] = zip;
+                mFiles[EmailOptions.ZIP_WITH_METADATA.getIndex()] = zip;
             }
             return results;
         }

--- a/app/src/main/res/layout/generate_report_layout.xml
+++ b/app/src/main/res/layout/generate_report_layout.xml
@@ -3,52 +3,73 @@
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical">
-	<Button style="@style/Widget.SmartReceipts.Button.Secondary"
-		android:id="@+id/generate_report_tooltip"
-		android:layout_width="match_parent"
-		android:layout_height="wrap_content"
-		android:text="@string/generate_report_tooltip"
-		android:gravity="center"/>
+
+    <Button
+        android:id="@+id/generate_report_tooltip"
+        style="@style/Widget.SmartReceipts.Button.Secondary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="@string/generate_report_tooltip" />
+
     <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/generate_report_tooltip"
         android:orientation="vertical"
-        android:layout_width="fill_parent"
-    	android:layout_height="wrap_content"
-		android:layout_below="@id/generate_report_tooltip"
         android:padding="@dimen/generate_report_padding">
 
-        <CheckBox android:id="@+id/DIALOG_EMAIL_CHECKBOX_PDF_FULL"
-            android:layout_width="fill_parent"
-    		android:layout_height="wrap_content"
-            android:textAppearance="@style/Widget.SmartReceipts.TextView.Title"
+        <CheckBox
+            android:id="@+id/dialog_email_checkbox_pdf_full"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/generate_report_item_separation"
-            android:paddingLeft="@dimen/generate_report_item_separation"
-            android:paddingRight="@dimen/generate_report_item_separation"
-    		android:text="@string/DIALOG_EMAIL_CHECKBOX_PDF_FULL" />
-        <CheckBox android:id="@+id/DIALOG_EMAIL_CHECKBOX_PDF_IMAGES"
-            android:layout_width="fill_parent"
-    		android:layout_height="wrap_content"
-            android:textAppearance="@style/Widget.SmartReceipts.TextView.Title"
+            android:paddingEnd="@dimen/generate_report_item_separation"
+            android:paddingStart="@dimen/generate_report_item_separation"
+            android:text="@string/DIALOG_EMAIL_CHECKBOX_PDF_FULL"
+            android:textAppearance="@style/Widget.SmartReceipts.TextView.Title" />
+
+        <CheckBox
+            android:id="@+id/dialog_email_checkbox_pdf_images"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/generate_report_item_separation"
-            android:paddingLeft="@dimen/generate_report_item_separation"
-            android:paddingRight="@dimen/generate_report_item_separation"
-    		android:text="@string/DIALOG_EMAIL_CHECKBOX_PDF_IMAGES" />
-        <CheckBox android:id="@+id/DIALOG_EMAIL_CHECKBOX_CSV"
-            android:layout_width="fill_parent"
-    		android:layout_height="wrap_content"
-            android:textAppearance="@style/Widget.SmartReceipts.TextView.Title"
+            android:paddingEnd="@dimen/generate_report_item_separation"
+            android:paddingStart="@dimen/generate_report_item_separation"
+            android:text="@string/DIALOG_EMAIL_CHECKBOX_PDF_IMAGES"
+            android:textAppearance="@style/Widget.SmartReceipts.TextView.Title" />
+
+        <CheckBox
+            android:id="@+id/dialog_email_checkbox_csv"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/generate_report_item_separation"
-            android:paddingLeft="@dimen/generate_report_item_separation"
-            android:paddingRight="@dimen/generate_report_item_separation"
-    		android:text="@string/DIALOG_EMAIL_CHECKBOX_CSV" />
-        <CheckBox android:id="@+id/DIALOG_EMAIL_CHECKBOX_ZIP_IMAGES_STAMPED"
-            android:layout_width="fill_parent"
-    		android:layout_height="wrap_content"
-            android:textAppearance="@style/Widget.SmartReceipts.TextView.Title"
-            android:paddingLeft="@dimen/generate_report_item_separation"
-            android:paddingRight="@dimen/generate_report_item_separation"
-    		android:text="@string/DIALOG_EMAIL_CHECKBOX_ZIP_IMAGES_STAMPED" />
+            android:paddingEnd="@dimen/generate_report_item_separation"
+            android:paddingStart="@dimen/generate_report_item_separation"
+            android:text="@string/DIALOG_EMAIL_CHECKBOX_CSV"
+            android:textAppearance="@style/Widget.SmartReceipts.TextView.Title" />
+
+        <CheckBox
+            android:id="@+id/dialog_email_checkbox_zip"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingEnd="@dimen/generate_report_item_separation"
+            android:paddingStart="@dimen/generate_report_item_separation"
+            android:text="@string/DIALOG_EMAIL_CHECKBOX_ZIP"
+            android:textAppearance="@style/Widget.SmartReceipts.TextView.Title" />
+
+        <CheckBox
+            android:id="@+id/dialog_email_checkbox_zip_with_metadata"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingEnd="@dimen/generate_report_item_separation"
+            android:paddingStart="@dimen/generate_report_item_separation"
+            android:text="@string/DIALOG_EMAIL_CHECKBOX_ZIP_WITH_METADATA"
+            android:textAppearance="@style/Widget.SmartReceipts.TextView.Title" />
     </LinearLayout>
-    <com.github.clans.fab.FloatingActionButton style="@style/Widget.SmartReceipts.FloatingActionButton"
+
+    <com.github.clans.fab.FloatingActionButton
         android:id="@+id/receipt_action_send"
+        style="@style/Widget.SmartReceipts.FloatingActionButton"
         android:src="@drawable/ic_action_send" />
 </RelativeLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -225,7 +225,8 @@
     <string name="DIALOG_EMAIL_CHECKBOX_PDF_FULL">Vollständiger PDF Bericht</string>
     <string name="DIALOG_EMAIL_CHECKBOX_PDF_IMAGES">PDF Bericht - Keine Tabelle</string>
     <string name="DIALOG_EMAIL_CHECKBOX_CSV">CSV-Datei</string>
-    <string name="DIALOG_EMAIL_CHECKBOX_ZIP_IMAGES_STAMPED">ZIP - Stamped JPGs</string>
+    <string name="DIALOG_EMAIL_CHECKBOX_ZIP_WITH_METADATA">ZIP - Quittungen Dateien mit Metadaten</string>
+    <string name="DIALOG_EMAIL_CHECKBOX_ZIP">ZIP - Quittungen Dateien</string>
     <string name="DIALOG_EMAIL_TOAST_NO_SELECTION">Bitte wählen Sie mindestens einen Bericht</string>
     <string name="DIALOG_EMAIL_TOAST_NO_RECEIPTS">Es gibt keine Belege in diesem Bericht</string>
     <string name="generate_report_tooltip">Tippen Sie auf die Berichtslayouts, um sie zu konfigurieren</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -225,7 +225,8 @@
     <string name="DIALOG_EMAIL_CHECKBOX_PDF_FULL">Informe PDF completo</string>
     <string name="DIALOG_EMAIL_CHECKBOX_PDF_IMAGES">Informe PDF - Sin tabla</string>
     <string name="DIALOG_EMAIL_CHECKBOX_CSV">Archivo CSV</string>
-    <string name="DIALOG_EMAIL_CHECKBOX_ZIP_IMAGES_STAMPED">ZIP: JPG estampados</string>
+    <string name="DIALOG_EMAIL_CHECKBOX_ZIP_WITH_METADATA">ZIP - Archivos de recibo con metadatos</string>
+    <string name="DIALOG_EMAIL_CHECKBOX_ZIP">ZIP - Archivos de Recibos</string>
     <string name="DIALOG_EMAIL_TOAST_NO_SELECTION">Por favor selecciona al menos un informe</string>
     <string name="DIALOG_EMAIL_TOAST_NO_RECEIPTS">Este informe no tiene recibos</string>
     <string name="generate_report_tooltip">Toca para configurar los diseños del informe</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -225,7 +225,8 @@
     <string name="DIALOG_EMAIL_CHECKBOX_PDF_FULL">Rapport PDF complet</string>
     <string name="DIALOG_EMAIL_CHECKBOX_PDF_IMAGES">Rapport PDF - Aucun tableau</string>
     <string name="DIALOG_EMAIL_CHECKBOX_CSV">Fichier CSV</string>
-    <string name="DIALOG_EMAIL_CHECKBOX_ZIP_IMAGES_STAMPED">ZIP - JPGs indiqués</string>
+    <string name="DIALOG_EMAIL_CHECKBOX_ZIP_WITH_METADATA">ZIP - Fichiers de reçus avec métadonnées</string>
+    <string name="DIALOG_EMAIL_CHECKBOX_ZIP">ZIP - Fichiers de reçus</string>
     <string name="DIALOG_EMAIL_TOAST_NO_SELECTION">Veuillez vérifier au moins un rapport</string>
     <string name="DIALOG_EMAIL_TOAST_NO_RECEIPTS">Il n’y a aucun reçu dans ce rapport</string>
     <string name="generate_report_tooltip">Cliquez pour configurer la mise en page du rapport</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -225,7 +225,8 @@
     <string name="DIALOG_EMAIL_CHECKBOX_PDF_FULL">Relatório PDF completo</string>
     <string name="DIALOG_EMAIL_CHECKBOX_PDF_IMAGES">Relatório PDF - Sem tabelas</string>
     <string name="DIALOG_EMAIL_CHECKBOX_CSV">Arquivo CSV</string>
-    <string name="DIALOG_EMAIL_CHECKBOX_ZIP_IMAGES_STAMPED">ZIP - JPGs com carimbo</string>
+    <string name="DIALOG_EMAIL_CHECKBOX_ZIP_WITH_METADATA">ZIP - Arquivos de Recebimento com Metadados</string>
+    <string name="DIALOG_EMAIL_CHECKBOX_ZIP">ZIP - Arquivos Receipts</string>
     <string name="DIALOG_EMAIL_TOAST_NO_SELECTION">Verifique pelo menos um relatório</string>
     <string name="DIALOG_EMAIL_TOAST_NO_RECEIPTS">Não há recibos nesse relatório</string>
     <string name="generate_report_tooltip">Toque para configurar os layouts dos relatórios</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -227,7 +227,8 @@
     <string name="DIALOG_EMAIL_CHECKBOX_PDF_FULL">Полный отчет в формате PDF</string>
     <string name="DIALOG_EMAIL_CHECKBOX_PDF_IMAGES">PDF отчет - без таблицы</string>
     <string name="DIALOG_EMAIL_CHECKBOX_CSV">Файл CSV</string>
-    <string name="DIALOG_EMAIL_CHECKBOX_ZIP_IMAGES_STAMPED">ZIP с JPG</string>
+    <string name="DIALOG_EMAIL_CHECKBOX_ZIP_WITH_METADATA">ZIP - файлы  чеков с метаданными</string>
+    <string name="DIALOG_EMAIL_CHECKBOX_ZIP">ZIP - файлы  чеков</string>
     <string name="DIALOG_EMAIL_TOAST_NO_SELECTION">Пожалуйста, выберите по крайней мере один отчет</string>
     <string name="DIALOG_EMAIL_TOAST_NO_RECEIPTS">Этот отчет не содержит чеков</string>
     <string name="generate_report_tooltip">Нажмите, чтобы настроить внешний вид отчета</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -227,7 +227,8 @@
     <string name="DIALOG_EMAIL_CHECKBOX_PDF_FULL">Повний звіт у форматі PDF</string>
     <string name="DIALOG_EMAIL_CHECKBOX_PDF_IMAGES">PDF звіт - без таблиці</string>
     <string name="DIALOG_EMAIL_CHECKBOX_CSV">Файл CSV</string>
-    <string name="DIALOG_EMAIL_CHECKBOX_ZIP_IMAGES_STAMPED">ZIP з JPG</string>
+    <string name="DIALOG_EMAIL_CHECKBOX_ZIP_WITH_METADATA">ZIP - файли чеків з метаданими</string>
+    <string name="DIALOG_EMAIL_CHECKBOX_ZIP">ZIP - файли чеків</string>
     <string name="DIALOG_EMAIL_TOAST_NO_SELECTION">Будь ласка, виберіть принаймні один звіт</string>
     <string name="DIALOG_EMAIL_TOAST_NO_RECEIPTS">Цей звіт не містить чеків</string>
     <string name="generate_report_tooltip">Натисніть, щоб налаштувати зовнішній вигляд звіту</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -236,7 +236,8 @@
     <string name="DIALOG_EMAIL_CHECKBOX_PDF_FULL">Full PDF Report</string>
     <string name="DIALOG_EMAIL_CHECKBOX_PDF_IMAGES">PDF Report - No Table</string>
     <string name="DIALOG_EMAIL_CHECKBOX_CSV">CSV File</string>
-    <string name="DIALOG_EMAIL_CHECKBOX_ZIP_IMAGES_STAMPED">ZIP - Stamped JPGs</string>
+    <string name="DIALOG_EMAIL_CHECKBOX_ZIP_WITH_METADATA">ZIP - Receipt Files with Metadata</string>
+    <string name="DIALOG_EMAIL_CHECKBOX_ZIP">ZIP - Receipts Files</string>
     <string name="DIALOG_EMAIL_TOAST_NO_SELECTION">Please Check At Least One Report</string>
     <string name="DIALOG_EMAIL_TOAST_NO_RECEIPTS">There are No Receipts in this Report</string>
     <string name="generate_report_tooltip">Tap to configure the report layouts</string>

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
         classpath 'com.google.gms:google-services:3.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "io.fabric.tools:gradle:1.25.1"


### PR DESCRIPTION
* Fixed bug when receipts could have `customOrderId` in `0, 1, 2...` format (described [here](https://trello.com/c/fBAl6MSW/348-fix-a-big-in-which-the-sorting-order-can-be-skewed-for-existing-users) )
* Fixed bug when generated reports which were exported to Google Drive have wrong name and have no extension
* Changed `ZIP - Receipt Files with Metadata` report behavior (now it also saves PDF attachments) 
* Added new report type `ZIP - Receipt Files` which saves all attachments in zip without stamping