### PR TITLE
Finished Hebrew Translations

### DIFF
--- a/app/src/main/res/values-he/preference_defaults.xml
+++ b/app/src/main/res/values-he/preference_defaults.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- ============= Preference General ================= -->
+    <integer name="pref_general_trip_duration_defaultValue">3</integer>
+    <string name="pref_general_default_currency_defaultValue" />
+    <string name="pref_general_default_date_separator_defaultValue" />
+    <bool name="pref_general_track_cost_center_defaultValue">false</bool>
+
+    <!-- ============== Preference Receipt ================ -->
+    <item name="pref_receipt_minimum_receipts_price_defaultValue" format="float" type="dimen">-1000.0</item>
+    <bool name="pref_receipt_predict_categories_defaultValue">true</bool>
+    <bool name="pref_receipt_match_name_to_category_defaultValue">false</bool>
+    <bool name="pref_receipt_match_comment_to_category_defaultValue">false</bool>
+    <bool name="pref_receipt_reimbursable_only_defaultValue">false</bool>
+    <bool name="pref_receipt_reimbursable_default_defaultValue">true</bool>
+    <bool name="pref_receipt_include_tax_field_defaultValue">false</bool>
+    <item name="pref_receipt_tax_percent_defaultValue" format="float" type="dimen">0.0</item>
+    <bool name="pref_receipt_pre_tax_defaultValue">true</bool>
+    <bool name="pref_receipt_enable_autocomplete_defaultValue">true</bool>
+    <bool name="pref_receipt_default_to_report_start_date_defaultValue">false</bool>
+    <bool name="pref_receipt_show_id_defaultValue">false</bool>
+    <bool name="pref_receipt_full_page_defaultValue">false</bool>
+    <bool name="pref_receipt_use_payment_methods_defaultValue">false</bool>
+
+    <!-- ============= Preference Output ================= -->
+    <string name="pref_output_username_defaultValue" />
+    <bool name="pref_output_print_receipt_id_by_photo_defaultValue">false</bool>
+    <bool name="pref_output_print_receipt_comment_by_photo_defaultValue">false</bool>
+    <bool name="pref_output_receipts_landscape_defaultValue">false</bool>
+    <string name="pref_output_pdf_page_size_defaultValue" translatable="false">@string/pref_output_pdf_page_size_a4_entryValue</string>
+
+    <!-- ============== Preference Email ================= -->
+    <string name="pref_email_default_email_to_defaultValue" />
+    <string name="pref_email_default_email_cc_defaultValue" />
+    <string name="pref_email_default_email_bcc_defaultValue" />
+    <string name="EMAIL_DATA_SUBJECT">Smart Receipts - %REPORT_NAME%</string> <!-- Note: The item should be "pref_email_default_email_subject_defaultValue" but cannot for legacy flex reasons -->
+
+    <!-- ============= Preference Camera ================= -->
+    <bool name="pref_camera_bw_defaultValue">false</bool>
+    <bool name="pref_camera_rotate_defaultValue">true</bool>
+
+    <!-- ============= Preference Layout ================= -->
+    <bool name="pref_layout_display_date_defaultValue">true</bool>
+    <bool name="pref_layout_display_category_defaultValue">false</bool>
+
+    <!-- ============= Preference Distance ================= -->
+    <item name="pref_distance_rate_defaultValue" format="float" type="dimen">0.0</item>
+    <bool name="pref_distance_include_price_in_report_defaultValue">false</bool>
+    <bool name="pref_distance_print_table_defaultValue">true</bool>
+    <bool name="pref_distance_print_daily_defaultValue">false</bool>
+    <bool name="pref_distance_as_price_defaultValue">true</bool>
+
+    <!-- ================= Preference Pro ================== -->
+    <string name="pref_pro_pdf_footer_defaultValue">Report Generated using Smart Receipts for Android</string>
+    <bool name="pref_pro_separate_by_category_defaultValue">false</bool>
+    <bool name="pref_pro_categorical_summation_defaultValue">false</bool>
+    <bool name="pref_pro_omit_default_table_defaultValue">false</bool>
+
+    <!-- ============== Preference Privacy ================= -->
+    <bool name="pref_privacy_enable_analytics_defaultValue">true</bool>
+    <bool name="pref_privacy_enable_crash_tracking_defaultValue">true</bool>
+    <bool name="pref_privacy_enable_ad_personalization_defaultValue">false</bool>
+
+    <!-- =============== Preference Misc =================== -->
+    <bool name="pref_no_category_auto_backup_wifi_only_defaultValue">true</bool>
+    <bool name="pref_no_category_ocr_incognito_mode_defaultValue">false</bool>
+    <bool name="pref_no_category_ocr_is_enabled_defaultValue">true</bool>
+
+</resources>

--- a/app/src/main/res/values-he/preferences.xml
+++ b/app/src/main/res/values-he/preferences.xml
@@ -22,85 +22,85 @@
 
     <!-- ============== Preference General ================= -->
     <string name="pref_general_trip_duration_key" translatable="false">TripDuration</string>
-    <string name="pref_general_trip_duration_title">Default Trip Length</string>
+    <string name="pref_general_trip_duration_title">אורך נסיעה ממוצע</string>
     <string name="pref_general_default_currency_key" translatable="false">isocurr</string>
-    <string name="pref_general_default_currency_title">Default Currency</string>
+    <string name="pref_general_default_currency_title">מטבע ברירת מחדל</string>
     <string name="pref_general_default_date_separator_key" translatable="false">dateseparator</string>
-    <string name="pref_general_default_date_separator_title">Default Date Separator</string>
+    <string name="pref_general_default_date_separator_title">מפריד תאריך ברירת מחדל</string>
     <string name="pref_general_track_cost_center_key" translatable="false">trackcostcenter</string>
-    <string name="pref_general_track_cost_center_title">Track Cost Center</string>
-    <string name="pref_general_track_cost_center_summaryOn">Include Cost Center For Reports</string>
-    <string name="pref_general_track_cost_center_summaryOff">Don\'t Include Cost Center For Reports</string>
+    <string name="pref_general_track_cost_center_title">חשב מרכז עלויות</string>
+    <string name="pref_general_track_cost_center_summaryOn">הכלל מרכז עלויות בדיווחים</string>
+    <string name="pref_general_track_cost_center_summaryOff">אל תכליל מרכז עלויות בדיווחים</string>
 
     <!-- ============== Preference Receipt ================= -->
     <string name="pref_receipt_customize_categories_key" translatable="false">CustomCategories</string>
-    <string name="pref_receipt_customize_categories_title">Customize Receipt Categories</string>
-    <string name="pref_receipt_customize_categories_summary">Tap here to add/edit your categories</string>
+    <string name="pref_receipt_customize_categories_title">התאמה אישית לקטגוריות</string>
+    <string name="pref_receipt_customize_categories_summary">לחץ כאן לשינוי/הוספת קטגוריה</string>
     <string name="pref_receipt_predict_categories_key" translatable="false">PredictCats</string>
-    <string name="pref_receipt_predict_categories_title">Predict Receipt Categories</string>
-    <string name="pref_receipt_predict_categories_summary">Auto-fill category based on prior data</string>
+    <string name="pref_receipt_predict_categories_title">חיזוי קטגוריות</string>
+    <string name="pref_receipt_predict_categories_summary">מלא קטגוריה באופן אוטומטי לפי מידע קודם</string>
     <string name="pref_receipt_match_name_to_category_key" translatable="false">MatchNameCats</string>
-    <string name="pref_receipt_match_name_to_category_title">Match Name to Category</string>
-    <string name="pref_receipt_match_name_to_category_summary">Automatically set name to category</string>
+    <string name="pref_receipt_match_name_to_category_title">התאם שם לקטגוריה</string>
+    <string name="pref_receipt_match_name_to_category_summary">התאם שם לקטגוריה באופן אוטומטי</string>
     <string name="pref_receipt_match_comment_to_category_key" translatable="false">MatchCommentCats</string>
-    <string name="pref_receipt_match_comment_to_category_title">Match Comment to Category</string>
-    <string name="pref_receipt_match_comment_to_category_summary">Automatically set comment to category</string>
+    <string name="pref_receipt_match_comment_to_category_title">התאם הערה לקטגוריה</string>
+    <string name="pref_receipt_match_comment_to_category_summary">התאם הערה לקטגוריה באופן אוטומטי</string>
     <string name="pref_receipt_reimbursable_only_key" translatable="false">OnlyIncludeExpensable</string>
-    <string name="pref_receipt_reimbursable_only_title">Only Report Reimbursable</string>
-    <string name="pref_receipt_reimbursable_only_summary">Omit other receipts from output</string>
+    <string name="pref_receipt_reimbursable_only_title">דווח רק על קבלות ברות-החזר</string>
+    <string name="pref_receipt_reimbursable_only_summary">הסר קבלות אחרות מהדוח</string>
     <string name="pref_receipt_reimbursable_default_key" translatable="false">ExpensableDefault</string>
-    <string name="pref_receipt_reimbursable_default_title">Receipts Default As Reimbursable</string>
+    <string name="pref_receipt_reimbursable_default_title">קבלות מסומנות כברות-החזר כברירת מחדל</string>
     <string name="pref_receipt_include_tax_field_key" translatable="false">IncludeTaxField</string>
-    <string name="pref_receipt_include_tax_field_title">Include Tax Field</string>
-    <string name="pref_receipt_include_tax_field_summary">Adds a line item for taxes</string>
+    <string name="pref_receipt_include_tax_field_title">הוסף שדה מס</string>
+    <string name="pref_receipt_include_tax_field_summary">מוסיף שורה עבור מיסים</string>
     <string name="pref_receipt_tax_percent_key" translatable="false">TaxPercentage</string>
-    <string name="pref_receipt_tax_percent_title">Default Tax Percentage</string>
+    <string name="pref_receipt_tax_percent_title">אחוז מס ברירת-מחדל</string>
     <string name="pref_receipt_pre_tax_key" translatable="false">PreTax</string>
-    <string name="pref_receipt_pre_tax_title">Assume Price is Pre-Tax</string>
-    <string name="pref_receipt_pre_tax_summary_on">Calculates Tax From a Pre-Tax Price</string>
-    <string name="pref_receipt_pre_tax_summary_off">Calculates Tax From a Post-Tax Price</string>
+    <string name="pref_receipt_pre_tax_title">הנח שמחיר הוא לפני מס</string>
+    <string name="pref_receipt_pre_tax_summary_on">מחשב מס ממחיר טרום ניכוי מס</string>
+    <string name="pref_receipt_pre_tax_summary_off">מחשב מס ממחיר לאחר ניכוי מס</string>
     <string name="pref_receipt_enable_autocomplete_key" translatable="false">EnableAutoCompleteSuggestions</string>
-    <string name="pref_receipt_enable_autocomplete_title">Enable AutoComplete Suggestions</string>
-    <string name="pref_receipt_enable_autocomplete_summary">Suggest values from previous values</string>
+    <string name="pref_receipt_enable_autocomplete_title">אפשר הצעות אוטומטיות להשלמה</string>
+    <string name="pref_receipt_enable_autocomplete_summary">מציע ערכים אפשריים מערכים קודמים</string>
     <string name="pref_receipt_minimum_receipts_price_key" translatable="false">MinReceiptPrice</string>
-    <string name="pref_receipt_minimum_receipts_price_title">Minimum Receipt Price</string>
-    <string name="pref_receipt_minimum_receipts_price_summary_all">Include all receipts in report</string>
-    <string name="pref_receipt_minimum_receipts_price_summary_partial">Only report receipt prices over %s</string>
+    <string name="pref_receipt_minimum_receipts_price_title">מחיר קבלה מינימלי</string>
+    <string name="pref_receipt_minimum_receipts_price_summary_all">הכלל את כל הקבלות בדוח</string>
+    <string name="pref_receipt_minimum_receipts_price_summary_partial">%s דווח רק על קבלות מעל</string>
     <string name="pref_receipt_default_to_report_start_date_key" translatable="false">DefaultToFirstReportDate</string>
-    <string name="pref_receipt_default_to_report_start_date_title">Default to Report Start Date</string>
-    <string name="pref_receipt_default_to_report_start_date_summary">Sets receipt date to match report date</string>
+    <string name="pref_receipt_default_to_report_start_date_title">קבע את תאריך תחילת הדוח כברירת מחדל</string>
+    <string name="pref_receipt_default_to_report_start_date_summary">קובע את תאריך הקבלה לתאריך תחילת הדוח</string>
     <string name="pref_receipt_show_id_key" translatable="false">ShowReceiptID</string>
-    <string name="pref_receipt_show_id_title">Show Receipt ID</string>
-    <string name="pref_receipt_show_id_summary">Displays an auto-generated ID field</string>
+    <string name="pref_receipt_show_id_title">הראה מזהה קבלה</string>
+    <string name="pref_receipt_show_id_summary">מראה מזהה לכל קבלה (מספר המוקצה אוטומטית)</string>
     <string name="pref_receipt_full_page_key" translatable="false">UseFullPage</string>
-    <string name="pref_receipt_full_page_title">Assume Full Page</string>
-    <string name="pref_receipt_full_page_summary">Marks Receipts as Full Page by Default</string>
+    <string name="pref_receipt_full_page_title">הנח דף מלא</string>
+    <string name="pref_receipt_full_page_summary">מסמן קבלות כדף מלא כברירת מחדל</string>
     <string name="pref_receipt_use_payment_methods_key" translatable="false">UsePaymentMethods</string>
-    <string name="pref_receipt_use_payment_methods_title">Enable Payment Methods</string>
-    <string name="pref_receipt_use_payment_methods_summary">Select to track payment methods for receipts</string>
+    <string name="pref_receipt_use_payment_methods_title">אפשר אמצעי תשלום</string>
+    <string name="pref_receipt_use_payment_methods_summary">סמן על מנת לעקוב אחרי אמצעי תשלום לקבלות</string>
     <string name="pref_receipt_payment_methods_key" translatable="false">PaymentMethods</string>
-    <string name="pref_receipt_payment_methods_title">Customize Payment Methods</string>
-    <string name="pref_receipt_payment_methods_summary">Tap here to add/edit payment methods</string>
+    <string name="pref_receipt_payment_methods_title">התאמה אישית לאמצעי תשלום</string>
+    <string name="pref_receipt_payment_methods_summary">לחץ כאן להוספה/שינוי אמצעי תשלום</string>
 
     <!-- ============= Preference Output ================= -->
     <string name="pref_output_custom_csv_key" translatable="false">CustomizeCSVOutput</string>
-    <string name="pref_output_custom_csv_title">Customize CSV Output</string>
+    <string name="pref_output_custom_csv_title">התאמה אישית לדוח אקסל</string>
     <string name="pref_output_custom_pdf_key" translatable="false">CustomizePDFOutput</string>
-    <string name="pref_output_custom_pdf_title">Customize PDF Output</string>
+    <string name="pref_output_custom_pdf_title">התאמה אישית לדוח פידיאף</string>
     <string name="pref_output_username_key" translatable="false">UserName</string>
-    <string name="pref_output_username_title">User ID</string>
-    <string name="pref_output_username_emptyValue">Used as a Custom Output Field</string>
+    <string name="pref_output_username_title">מזהה משתמש</string>
+    <string name="pref_output_username_emptyValue">משמש כשדה ייצוא בהתאמה אישית</string>
     <string name="pref_output_print_receipt_id_by_photo_key" translatable="false">PrintByIDPhotoKey</string>
-    <string name="pref_output_print_receipt_id_by_photo_title">Print ID By Photo</string>
-    <string name="pref_output_print_receipt_id_by_photo_summary">Shows the Receipt ID instead of Index</string>
+    <string name="pref_output_print_receipt_id_by_photo_title">הראה מזהה לפי תמונה</string>
+    <string name="pref_output_print_receipt_id_by_photo_summary">מראה את מזהה את קבלה במקום מספר אינדקס</string>
     <string name="pref_output_print_receipt_comment_by_photo_key" translatable="false">PrintCommentByPhoto</string>
-    <string name="pref_output_print_receipt_comment_by_photo_title">Print Receipt Comment By Photo</string>
-    <string name="pref_output_print_receipt_comment_by_photo_summaryOn">Shows the Receipt comment above PDF photos</string>
-    <string name="pref_output_print_receipt_comment_by_photo_summaryOff">Hide the Receipt comment above PDF photos</string>
+    <string name="pref_output_print_receipt_comment_by_photo_title">הראה הערה לקבלה לפי תמונה</string>
+    <string name="pref_output_print_receipt_comment_by_photo_summaryOn">מראה הערה לקבלה מעל תמונות פידיאף</string>
+    <string name="pref_output_print_receipt_comment_by_photo_summaryOff">מחביא הערה לקבלה מתחת לתמונות פידיאף</string>
     <string name="pref_output_receipts_landscape_key" translatable="false">ReceiptsTableLandscape</string>
-    <string name="pref_output_receipts_landscape_title">Print receipts table in landscape mode</string>
-    <string name="pref_output_receipts_landscape_on">Receipts table is printed in landscape mode</string>
-    <string name="pref_output_receipts_landscape_off">Receipts table is printed in portrait mode</string>
+    <string name="pref_output_receipts_landscape_title">מדפיס טבלת קבלות בדף מאוזן</string>
+    <string name="pref_output_receipts_landscape_on">טבלת קבלות מודפסת בדף מאוזן</string>
+    <string name="pref_output_receipts_landscape_off">טבלת קבלות מודפסת בדף מאונך</string>
     <string name="pref_output_pdf_page_size_key" translatable="false">PdfPageSize</string>
     <string name="pref_output_pdf_page_size_a4_entryValue" translatable="false">A4</string>
     <string name="pref_output_pdf_page_size_letter_entryValue" translatable="false">Letter</string>
@@ -115,31 +115,31 @@
 
     <!-- ============== Preference Email ================= -->
     <string name="pref_email_default_email_to_key" translatable="false">EmailTo</string>
-    <string name="pref_email_default_email_to_title">Default Email To Recipient</string>
+    <string name="pref_email_default_email_to_title">כתובת אימייל ברירת מחדל למשלוח הדוח</string>
     <string name="pref_email_default_email_cc_key" translatable="false">EmailCC</string>
-    <string name="pref_email_default_email_cc_title">Default Email CC Recipient</string>
+    <string name="pref_email_default_email_cc_title">כתובת אימייל ברירת מחדל למשלוח העתק של הדוח</string>
     <string name="pref_email_default_email_bcc_key" translatable="false">EmailBCC</string>
-    <string name="pref_email_default_email_bcc_title">Default Email BCC Recipient</string>
-    <string name="pref_email_default_email_emptyValue">Separate values with a semicolon (;)</string>
+    <string name="pref_email_default_email_bcc_title">כתובת אימייל בריבת מחדל למשלוח העתק מוסתר של הדוח</string>
+    <string name="pref_email_default_email_emptyValue">(;) הפרד ערכים עם פסיקודה</string>
     <string name="pref_email_default_email_subject_key" translatable="false">EmailSubject</string>
-    <string name="pref_email_default_email_subject_title">Default Email Subject</string>
+    <string name="pref_email_default_email_subject_title">כותרת אימייל ברירת מחדל</string>
 
     <!-- ============= Preference Camera ================= -->
     <string name="pref_camera_bw_key" translatable="false">SaveBW</string>
-    <string name="pref_camera_bw_title">Convert to Grayscale</string>
-    <string name="pref_camera_bw_summary">Saves image in black and white</string>
+    <string name="pref_camera_bw_title">המר לגווני אפור</string>
+    <string name="pref_camera_bw_summary">שומר תמונה בשחור ולבן</string>
     <string name="pref_camera_rotate_key" translatable="false">Camera_Rotate</string>
-    <string name="pref_camera_rotate_title">Automatically rotate images</string>
-    <string name="pref_camera_rotate_summaryOn">Try to rotate images upright</string>
-    <string name="pref_camera_rotate_summaryOff">Do not rotate images</string>
+    <string name="pref_camera_rotate_title">סובב תמונות באופן אוטומטי</string>
+    <string name="pref_camera_rotate_summaryOn">נסה לסובב את התמונה לכיוון הנכון</string>
+    <string name="pref_camera_rotate_summaryOff">אל תסובב תמונות</string>
 
     <!-- ============= Preference Layout ================= -->
     <string name="pref_layout_display_date_key" translatable="false">LayoutIncludeReceiptDate</string>
-    <string name="pref_layout_display_date_title">Include Receipt Date</string>
-    <string name="pref_layout_display_date_summary">Shows the date of receipt list items</string>
+    <string name="pref_layout_display_date_title">כלול תאריך קבלה</string>
+    <string name="pref_layout_display_date_summary">מראה תאריך לכל קבלה ברשימת הקבלות</string>
     <string name="pref_layout_display_category_key" translatable="false">LayoutIncludeReceiptCategory</string>
-    <string name="pref_layout_display_category_title">Include Receipt Category</string>
-    <string name="pref_layout_display_category_summary">Shows the category of receipt list items</string>
+    <string name="pref_layout_display_category_title">הכלל קטגוריית קבלה</string>
+    <string name="pref_layout_display_category_summary">מראה קטגוריה לכל קבלה ברשימת הקבלות</string>
 
     <!-- ============= Preference Distance ================= -->
     <string name="pref_distance_include_price_in_report_key" translatable="false">MileageTotalInReport</string>

--- a/app/src/main/res/values-he/preferences.xml
+++ b/app/src/main/res/values-he/preferences.xml
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- ============== Preference Headers ================= -->
+    <string name="pref_header_key" translatable="false">HeaderKey</string>
+    <string name="pref_general_header">General</string>
+    <string name="pref_receipt_header">Receipts</string>
+    <string name="pref_output_header">Report Output</string>
+    <string name="pref_output_header_key" translatable="false">pref_output_category_key</string>
+    <string name="pref_email_header">Email</string>
+    <string name="pref_camera_header">Camera</string>
+    <string name="pref_camera_header_key" translatable="false">pref_camera_category_key</string>
+    <string name="pref_layout_header">Layout Customizations</string>
+    <string name="pref_distance_header">Distance</string>
+    <string name="pref_distance_header_key" translatable="false">pref_distance_category_key</string>
+    <string name="pref_pro_header">Smart Receipts Plus</string>
+    <string name="pref_help_header">Support</string>
+    <string name="pref_about_header">About</string>
+    <string name="pref_privacy_header_key" translatable="false">pref_privacy_category_key</string>
+    <string name="pref_privacy_header">Privacy</string>
+
+
+    <!-- ============== Preference General ================= -->
+    <string name="pref_general_trip_duration_key" translatable="false">TripDuration</string>
+    <string name="pref_general_trip_duration_title">Default Trip Length</string>
+    <string name="pref_general_default_currency_key" translatable="false">isocurr</string>
+    <string name="pref_general_default_currency_title">Default Currency</string>
+    <string name="pref_general_default_date_separator_key" translatable="false">dateseparator</string>
+    <string name="pref_general_default_date_separator_title">Default Date Separator</string>
+    <string name="pref_general_track_cost_center_key" translatable="false">trackcostcenter</string>
+    <string name="pref_general_track_cost_center_title">Track Cost Center</string>
+    <string name="pref_general_track_cost_center_summaryOn">Include Cost Center For Reports</string>
+    <string name="pref_general_track_cost_center_summaryOff">Don\'t Include Cost Center For Reports</string>
+
+    <!-- ============== Preference Receipt ================= -->
+    <string name="pref_receipt_customize_categories_key" translatable="false">CustomCategories</string>
+    <string name="pref_receipt_customize_categories_title">Customize Receipt Categories</string>
+    <string name="pref_receipt_customize_categories_summary">Tap here to add/edit your categories</string>
+    <string name="pref_receipt_predict_categories_key" translatable="false">PredictCats</string>
+    <string name="pref_receipt_predict_categories_title">Predict Receipt Categories</string>
+    <string name="pref_receipt_predict_categories_summary">Auto-fill category based on prior data</string>
+    <string name="pref_receipt_match_name_to_category_key" translatable="false">MatchNameCats</string>
+    <string name="pref_receipt_match_name_to_category_title">Match Name to Category</string>
+    <string name="pref_receipt_match_name_to_category_summary">Automatically set name to category</string>
+    <string name="pref_receipt_match_comment_to_category_key" translatable="false">MatchCommentCats</string>
+    <string name="pref_receipt_match_comment_to_category_title">Match Comment to Category</string>
+    <string name="pref_receipt_match_comment_to_category_summary">Automatically set comment to category</string>
+    <string name="pref_receipt_reimbursable_only_key" translatable="false">OnlyIncludeExpensable</string>
+    <string name="pref_receipt_reimbursable_only_title">Only Report Reimbursable</string>
+    <string name="pref_receipt_reimbursable_only_summary">Omit other receipts from output</string>
+    <string name="pref_receipt_reimbursable_default_key" translatable="false">ExpensableDefault</string>
+    <string name="pref_receipt_reimbursable_default_title">Receipts Default As Reimbursable</string>
+    <string name="pref_receipt_include_tax_field_key" translatable="false">IncludeTaxField</string>
+    <string name="pref_receipt_include_tax_field_title">Include Tax Field</string>
+    <string name="pref_receipt_include_tax_field_summary">Adds a line item for taxes</string>
+    <string name="pref_receipt_tax_percent_key" translatable="false">TaxPercentage</string>
+    <string name="pref_receipt_tax_percent_title">Default Tax Percentage</string>
+    <string name="pref_receipt_pre_tax_key" translatable="false">PreTax</string>
+    <string name="pref_receipt_pre_tax_title">Assume Price is Pre-Tax</string>
+    <string name="pref_receipt_pre_tax_summary_on">Calculates Tax From a Pre-Tax Price</string>
+    <string name="pref_receipt_pre_tax_summary_off">Calculates Tax From a Post-Tax Price</string>
+    <string name="pref_receipt_enable_autocomplete_key" translatable="false">EnableAutoCompleteSuggestions</string>
+    <string name="pref_receipt_enable_autocomplete_title">Enable AutoComplete Suggestions</string>
+    <string name="pref_receipt_enable_autocomplete_summary">Suggest values from previous values</string>
+    <string name="pref_receipt_minimum_receipts_price_key" translatable="false">MinReceiptPrice</string>
+    <string name="pref_receipt_minimum_receipts_price_title">Minimum Receipt Price</string>
+    <string name="pref_receipt_minimum_receipts_price_summary_all">Include all receipts in report</string>
+    <string name="pref_receipt_minimum_receipts_price_summary_partial">Only report receipt prices over %s</string>
+    <string name="pref_receipt_default_to_report_start_date_key" translatable="false">DefaultToFirstReportDate</string>
+    <string name="pref_receipt_default_to_report_start_date_title">Default to Report Start Date</string>
+    <string name="pref_receipt_default_to_report_start_date_summary">Sets receipt date to match report date</string>
+    <string name="pref_receipt_show_id_key" translatable="false">ShowReceiptID</string>
+    <string name="pref_receipt_show_id_title">Show Receipt ID</string>
+    <string name="pref_receipt_show_id_summary">Displays an auto-generated ID field</string>
+    <string name="pref_receipt_full_page_key" translatable="false">UseFullPage</string>
+    <string name="pref_receipt_full_page_title">Assume Full Page</string>
+    <string name="pref_receipt_full_page_summary">Marks Receipts as Full Page by Default</string>
+    <string name="pref_receipt_use_payment_methods_key" translatable="false">UsePaymentMethods</string>
+    <string name="pref_receipt_use_payment_methods_title">Enable Payment Methods</string>
+    <string name="pref_receipt_use_payment_methods_summary">Select to track payment methods for receipts</string>
+    <string name="pref_receipt_payment_methods_key" translatable="false">PaymentMethods</string>
+    <string name="pref_receipt_payment_methods_title">Customize Payment Methods</string>
+    <string name="pref_receipt_payment_methods_summary">Tap here to add/edit payment methods</string>
+
+    <!-- ============= Preference Output ================= -->
+    <string name="pref_output_custom_csv_key" translatable="false">CustomizeCSVOutput</string>
+    <string name="pref_output_custom_csv_title">Customize CSV Output</string>
+    <string name="pref_output_custom_pdf_key" translatable="false">CustomizePDFOutput</string>
+    <string name="pref_output_custom_pdf_title">Customize PDF Output</string>
+    <string name="pref_output_username_key" translatable="false">UserName</string>
+    <string name="pref_output_username_title">User ID</string>
+    <string name="pref_output_username_emptyValue">Used as a Custom Output Field</string>
+    <string name="pref_output_print_receipt_id_by_photo_key" translatable="false">PrintByIDPhotoKey</string>
+    <string name="pref_output_print_receipt_id_by_photo_title">Print ID By Photo</string>
+    <string name="pref_output_print_receipt_id_by_photo_summary">Shows the Receipt ID instead of Index</string>
+    <string name="pref_output_print_receipt_comment_by_photo_key" translatable="false">PrintCommentByPhoto</string>
+    <string name="pref_output_print_receipt_comment_by_photo_title">Print Receipt Comment By Photo</string>
+    <string name="pref_output_print_receipt_comment_by_photo_summaryOn">Shows the Receipt comment above PDF photos</string>
+    <string name="pref_output_print_receipt_comment_by_photo_summaryOff">Hide the Receipt comment above PDF photos</string>
+    <string name="pref_output_receipts_landscape_key" translatable="false">ReceiptsTableLandscape</string>
+    <string name="pref_output_receipts_landscape_title">Print receipts table in landscape mode</string>
+    <string name="pref_output_receipts_landscape_on">Receipts table is printed in landscape mode</string>
+    <string name="pref_output_receipts_landscape_off">Receipts table is printed in portrait mode</string>
+    <string name="pref_output_pdf_page_size_key" translatable="false">PdfPageSize</string>
+    <string name="pref_output_pdf_page_size_a4_entryValue" translatable="false">A4</string>
+    <string name="pref_output_pdf_page_size_letter_entryValue" translatable="false">Letter</string>
+    <string-array name="pref_output_pdf_page_size_value_entryValues">
+        <item>@string/pref_output_pdf_page_size_a4_entryValue</item>
+        <item>@string/pref_output_pdf_page_size_letter_entryValue</item>
+    </string-array>
+    <string-array name="pref_output_pdf_page_size_value_entries">
+        <item>@string/pref_output_pdf_page_size_a4_entry</item>
+        <item>@string/pref_output_pdf_page_size_letter_entry</item>
+    </string-array>
+
+    <!-- ============== Preference Email ================= -->
+    <string name="pref_email_default_email_to_key" translatable="false">EmailTo</string>
+    <string name="pref_email_default_email_to_title">Default Email To Recipient</string>
+    <string name="pref_email_default_email_cc_key" translatable="false">EmailCC</string>
+    <string name="pref_email_default_email_cc_title">Default Email CC Recipient</string>
+    <string name="pref_email_default_email_bcc_key" translatable="false">EmailBCC</string>
+    <string name="pref_email_default_email_bcc_title">Default Email BCC Recipient</string>
+    <string name="pref_email_default_email_emptyValue">Separate values with a semicolon (;)</string>
+    <string name="pref_email_default_email_subject_key" translatable="false">EmailSubject</string>
+    <string name="pref_email_default_email_subject_title">Default Email Subject</string>
+
+    <!-- ============= Preference Camera ================= -->
+    <string name="pref_camera_bw_key" translatable="false">SaveBW</string>
+    <string name="pref_camera_bw_title">Convert to Grayscale</string>
+    <string name="pref_camera_bw_summary">Saves image in black and white</string>
+    <string name="pref_camera_rotate_key" translatable="false">Camera_Rotate</string>
+    <string name="pref_camera_rotate_title">Automatically rotate images</string>
+    <string name="pref_camera_rotate_summaryOn">Try to rotate images upright</string>
+    <string name="pref_camera_rotate_summaryOff">Do not rotate images</string>
+
+    <!-- ============= Preference Layout ================= -->
+    <string name="pref_layout_display_date_key" translatable="false">LayoutIncludeReceiptDate</string>
+    <string name="pref_layout_display_date_title">Include Receipt Date</string>
+    <string name="pref_layout_display_date_summary">Shows the date of receipt list items</string>
+    <string name="pref_layout_display_category_key" translatable="false">LayoutIncludeReceiptCategory</string>
+    <string name="pref_layout_display_category_title">Include Receipt Category</string>
+    <string name="pref_layout_display_category_summary">Shows the category of receipt list items</string>
+
+    <!-- ============= Preference Distance ================= -->
+    <string name="pref_distance_include_price_in_report_key" translatable="false">MileageTotalInReport</string>
+    <string name="pref_distance_include_price_in_report_title">Add Distance Price to Report</string>
+    <string name="pref_distance_include_price_in_report_summaryOn">Includes distance price in report total</string>
+    <string name="pref_distance_include_price_in_report_summaryOff">Excludes distance price from report total</string>
+    <string name="pref_distance_rate_key" translatable="false">MileageRate</string>
+    <string name="pref_distance_rate_title">Gas Rate</string>
+    <string name="pref_distance_rate_summaryOff">The rate per mi or km travelled</string>
+    <string name="pref_distance_rate_summaryOn">%s per mi or km</string>
+    <string name="pref_distance_print_table_key" translatable="false">MileagePrintTable</string>
+    <string name="pref_distance_print_table_title">Include Distance Table</string>
+    <string name="pref_distance_print_table_summaryOn">PDF/CSV reports include distance table</string>
+    <string name="pref_distance_print_table_summaryOff">PDF/CSV reports don\'t include distance table</string>
+    <string name="pref_distance_print_daily_key" translatable="false">MileageAddToPDF</string>
+    <string name="pref_distance_print_daily_title">Report on Daily Distance</string>
+    <string name="pref_distance_print_daily_summaryOn">Show distance as receipt line item</string>
+    <string name="pref_distance_print_daily_summaryOff">Don\'t show distance as receipt line item</string>
+    <string name="pref_distance_as_price_key" translatable="false">DistanceAsPrice</string>
+    <string name="pref_distance_as_price_title">Distance Price in Subtitle</string>
+    <string name="pref_distance_as_price_summaryOn">Show distance price total in app subtitle</string>
+    <string name="pref_distance_as_price_summaryOff">Show distance travelled in app subtitle</string>
+
+    <!-- ================= Preference Plus ================== -->
+    <string name="pref_pro_pdf_footer_key" translatable="false">PdfFooterString</string>
+    <string name="pref_pro_pdf_footer_title">PDF Footer Text</string>
+    <string name="pref_pro_separate_by_category_key" translatable="false">SeparateByCategory</string>
+    <string name="pref_pro_separate_by_category_title">Separate Payments by Category</string>
+    <string name="pref_pro_separate_by_category_summaryOn">PDF/CSV reports include separate tables for different categories</string>
+    <string name="pref_pro_separate_by_category_summaryOff">PDF/CSV reports don\'t include separate tables for different categories</string>
+    <string name="pref_pro_categorical_summation_key" translatable="false">IncludeCategoricalSummation</string>
+    <string name="pref_pro_categorical_summation_title">Include Categorical Summation</string>
+    <string name="pref_pro_categorical_summation_summaryOn">PDF/CSV reports include table with summation by category</string>
+    <string name="pref_pro_categorical_summation_summaryOff">PDF/CSV reports don\'t include table with summation by category</string>
+    <string name="pref_pro_omit_default_table_key" translatable="false">OmitDefaultPDFTable</string>
+    <string name="pref_pro_omit_default_table_title">Omit Default PDF Table</string>
+
+    <!-- ============== Preference Support ================= -->
+    <string name="pref_help_send_love_key" translatable="false">SendLove</string>
+    <string name="pref_help_send_love_title">Send Love</string>
+    <string name="pref_help_send_feedback_key" translatable="false">SendFeedback</string>
+    <string name="pref_help_send_feedback_title">Send Feedback</string>
+    <string name="pref_help_support_email_key" translatable="false">SupportEmail</string>
+    <string name="pref_help_support_email_title">Email for Support</string>
+
+    <!-- =============== Preference About ================== -->
+    <string name="pref_about_version_key" translatable="false">VersionNo</string>
+    <string name="pref_about_version_title">Version</string>
+    <string name="pref_about_about_key" translatable="false">About</string>
+    <string name="pref_about_about_title">About</string>
+    <string name="pref_about_about_dialogMessage">Smart Receipts was created and is maintained by Smart Receipts LLC. It is licensed under GNU Affero General Public License</string>
+    <string name="pref_about_terms_key" translatable="false">TermsOfUse</string>
+    <string name="pref_about_terms_title">Terms of Use</string>
+    <string name="pref_about_terms_dialogMessage">This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.\n\nThis program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.\n\nYou can view a copy of the GNU Affero General Public License at http://www.gnu.org/licenses/.</string>
+
+    <!-- ============== Preference Privacy ================= -->
+    <string name="pref_about_privacy_policy_key" translatable="false">PrivacyPolicy</string>
+    <string name="pref_about_privacy_policy_title">Privacy Policy</string>
+    <string name="pref_privacy_enable_analytics_key" translatable="false">EnableAnalytics</string>
+    <string name="pref_privacy_enable_analytics_title">Share Analytics</string>
+    <string name="pref_privacy_enable_analytics_summary">With Google/Firebase Analytics</string>
+    <string name="pref_privacy_enable_crash_tracking_key" translatable="false">EnableCrashTracking</string>
+    <string name="pref_privacy_enable_crash_tracking_title">Share Crash Information</string>
+    <string name="pref_privacy_enable_crash_tracking_summary">With Google Crashlytics</string>
+    <string name="pref_privacy_enable_ad_personalization_key" translatable="false">EnableAdPersonalization</string>
+    <string name="pref_privacy_enable_ad_personalization_title">Allow Ad Personalization</string>
+    <string name="pref_privacy_enable_ad_personalization_summary">With Google AdMob</string>
+
+    <!-- =============== Preference Misc =================== -->
+    <string name="pref_no_category_auto_backup_wifi_only_key" translatable="false">AutoBackupWifiOnly</string>
+    <string name="pref_no_category_ocr_incognito_mode_key" translatable="false">OcrIncognitoMode</string>
+    <string name="pref_no_category_ocr_is_enabled_key" translatable="false">OcrIsEnabled</string>
+
+</resources>

--- a/app/src/main/res/values-he/preferences.xml
+++ b/app/src/main/res/values-he/preferences.xml
@@ -3,21 +3,21 @@
 
     <!-- ============== Preference Headers ================= -->
     <string name="pref_header_key" translatable="false">HeaderKey</string>
-    <string name="pref_general_header">General</string>
-    <string name="pref_receipt_header">Receipts</string>
-    <string name="pref_output_header">Report Output</string>
+    <string name="pref_general_header">כללי</string>
+    <string name="pref_receipt_header">חשבוניות</string>
+    <string name="pref_output_header">דוח מיוצא</string>
     <string name="pref_output_header_key" translatable="false">pref_output_category_key</string>
-    <string name="pref_email_header">Email</string>
-    <string name="pref_camera_header">Camera</string>
+    <string name="pref_email_header">אימייל</string>
+    <string name="pref_camera_header">מלצמה</string>
     <string name="pref_camera_header_key" translatable="false">pref_camera_category_key</string>
-    <string name="pref_layout_header">Layout Customizations</string>
-    <string name="pref_distance_header">Distance</string>
+    <string name="pref_layout_header">התאמה אישית (עיצוב)</string>
+    <string name="pref_distance_header">מרחק</string>
     <string name="pref_distance_header_key" translatable="false">pref_distance_category_key</string>
     <string name="pref_pro_header">Smart Receipts Plus</string>
-    <string name="pref_help_header">Support</string>
-    <string name="pref_about_header">About</string>
+    <string name="pref_help_header">תמיכה</string>
+    <string name="pref_about_header">אודות</string>
     <string name="pref_privacy_header_key" translatable="false">pref_privacy_category_key</string>
-    <string name="pref_privacy_header">Privacy</string>
+    <string name="pref_privacy_header">פרטיות</string>
 
 
     <!-- ============== Preference General ================= -->

--- a/app/src/main/res/values-he/preferences.xml
+++ b/app/src/main/res/values-he/preferences.xml
@@ -143,70 +143,70 @@
 
     <!-- ============= Preference Distance ================= -->
     <string name="pref_distance_include_price_in_report_key" translatable="false">MileageTotalInReport</string>
-    <string name="pref_distance_include_price_in_report_title">Add Distance Price to Report</string>
-    <string name="pref_distance_include_price_in_report_summaryOn">Includes distance price in report total</string>
-    <string name="pref_distance_include_price_in_report_summaryOff">Excludes distance price from report total</string>
+    <string name="pref_distance_include_price_in_report_title">הוסף מחיר נסיעה לדוח</string>
+    <string name="pref_distance_include_price_in_report_summaryOn">מוסיף מחיר נסיעה לסכימה בדוח</string>
+    <string name="pref_distance_include_price_in_report_summaryOff">לא מוסיף מחיר נסיעה לסכימה בדוח</string>
     <string name="pref_distance_rate_key" translatable="false">MileageRate</string>
-    <string name="pref_distance_rate_title">Gas Rate</string>
-    <string name="pref_distance_rate_summaryOff">The rate per mi or km travelled</string>
-    <string name="pref_distance_rate_summaryOn">%s per mi or km</string>
+    <string name="pref_distance_rate_title">מחיר לדלק</string>
+    <string name="pref_distance_rate_summaryOff">מחיר לפי קילומטר או מייל של נסיעה</string>
+    <string name="pref_distance_rate_summaryOn">לכל מייל או קילומטר %s</string>
     <string name="pref_distance_print_table_key" translatable="false">MileagePrintTable</string>
-    <string name="pref_distance_print_table_title">Include Distance Table</string>
-    <string name="pref_distance_print_table_summaryOn">PDF/CSV reports include distance table</string>
-    <string name="pref_distance_print_table_summaryOff">PDF/CSV reports don\'t include distance table</string>
+    <string name="pref_distance_print_table_title">הוסף טבלת מרחק נסיעה</string>
+    <string name="pref_distance_print_table_summaryOn">דוחות פידיאף ואקסל כוללים טבלת מרחק נסיעה</string>
+    <string name="pref_distance_print_table_summaryOff">דוחות פידיאף ואקסל לא כוללים טבלת מרחק נסיעה</string>
     <string name="pref_distance_print_daily_key" translatable="false">MileageAddToPDF</string>
-    <string name="pref_distance_print_daily_title">Report on Daily Distance</string>
-    <string name="pref_distance_print_daily_summaryOn">Show distance as receipt line item</string>
-    <string name="pref_distance_print_daily_summaryOff">Don\'t show distance as receipt line item</string>
+    <string name="pref_distance_print_daily_title">דווח על מרחק נסיעה יומי</string>
+    <string name="pref_distance_print_daily_summaryOn">הראה מרחק נסיעה לכל קבלה</string>
+    <string name="pref_distance_print_daily_summaryOff">אל תראה מרחק נסיעה לכל קבלה</string>
     <string name="pref_distance_as_price_key" translatable="false">DistanceAsPrice</string>
-    <string name="pref_distance_as_price_title">Distance Price in Subtitle</string>
-    <string name="pref_distance_as_price_summaryOn">Show distance price total in app subtitle</string>
-    <string name="pref_distance_as_price_summaryOff">Show distance travelled in app subtitle</string>
+    <string name="pref_distance_as_price_title">מחיר מרחק נסיעה בכותרת משנה</string>
+    <string name="pref_distance_as_price_summaryOn">הראה סך הכול מחיר נסיעה בכותרת משנה</string>
+    <string name="pref_distance_as_price_summaryOff">הראה סך הכול מרחק נסיעה בכותרת משנה</string>
 
     <!-- ================= Preference Plus ================== -->
     <string name="pref_pro_pdf_footer_key" translatable="false">PdfFooterString</string>
-    <string name="pref_pro_pdf_footer_title">PDF Footer Text</string>
+    <string name="pref_pro_pdf_footer_title">טקסט בתחתית מסמך פידיאף</string>
     <string name="pref_pro_separate_by_category_key" translatable="false">SeparateByCategory</string>
-    <string name="pref_pro_separate_by_category_title">Separate Payments by Category</string>
-    <string name="pref_pro_separate_by_category_summaryOn">PDF/CSV reports include separate tables for different categories</string>
-    <string name="pref_pro_separate_by_category_summaryOff">PDF/CSV reports don\'t include separate tables for different categories</string>
+    <string name="pref_pro_separate_by_category_title">הפרד תשלומים לפי קטגוריה</string>
+    <string name="pref_pro_separate_by_category_summaryOn">דוחות פידיאף ואקסל מכילים טבלאות שונות לפי קטגוריה</string>
+    <string name="pref_pro_separate_by_category_summaryOff">דוחות פידיאף ואקסל לא מכילים טבלאות שונות לפי קטגוריה</string>
     <string name="pref_pro_categorical_summation_key" translatable="false">IncludeCategoricalSummation</string>
-    <string name="pref_pro_categorical_summation_title">Include Categorical Summation</string>
-    <string name="pref_pro_categorical_summation_summaryOn">PDF/CSV reports include table with summation by category</string>
-    <string name="pref_pro_categorical_summation_summaryOff">PDF/CSV reports don\'t include table with summation by category</string>
+    <string name="pref_pro_categorical_summation_title">כלול סכימה לפי קטגרויה</string>
+    <string name="pref_pro_categorical_summation_summaryOn">דוחות פידיאף ואקסל מכילים טבלאות של סכימה לפי קטגוריה</string>
+    <string name="pref_pro_categorical_summation_summaryOff">דוחות פידיאף ואקסל לא מכילים טבלאות של סכימה לפי קטגוריה</string>
     <string name="pref_pro_omit_default_table_key" translatable="false">OmitDefaultPDFTable</string>
-    <string name="pref_pro_omit_default_table_title">Omit Default PDF Table</string>
+    <string name="pref_pro_omit_default_table_title">אל תכלול טבלת פידיאף ברירת מחדל</string>
 
     <!-- ============== Preference Support ================= -->
     <string name="pref_help_send_love_key" translatable="false">SendLove</string>
-    <string name="pref_help_send_love_title">Send Love</string>
+    <string name="pref_help_send_love_title">(:שלח אהבה</string>
     <string name="pref_help_send_feedback_key" translatable="false">SendFeedback</string>
-    <string name="pref_help_send_feedback_title">Send Feedback</string>
+    <string name="pref_help_send_feedback_title">שלח פידבק</string>
     <string name="pref_help_support_email_key" translatable="false">SupportEmail</string>
-    <string name="pref_help_support_email_title">Email for Support</string>
+    <string name="pref_help_support_email_title">שלח אימייל לתמיכה טכנית</string>
 
     <!-- =============== Preference About ================== -->
     <string name="pref_about_version_key" translatable="false">VersionNo</string>
-    <string name="pref_about_version_title">Version</string>
+    <string name="pref_about_version_title">גרסא</string>
     <string name="pref_about_about_key" translatable="false">About</string>
-    <string name="pref_about_about_title">About</string>
+    <string name="pref_about_about_title">אודות</string>
     <string name="pref_about_about_dialogMessage">Smart Receipts was created and is maintained by Smart Receipts LLC. It is licensed under GNU Affero General Public License</string>
     <string name="pref_about_terms_key" translatable="false">TermsOfUse</string>
-    <string name="pref_about_terms_title">Terms of Use</string>
+    <string name="pref_about_terms_title">תנאי שימוש</string>
     <string name="pref_about_terms_dialogMessage">This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.\n\nThis program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.\n\nYou can view a copy of the GNU Affero General Public License at http://www.gnu.org/licenses/.</string>
 
     <!-- ============== Preference Privacy ================= -->
     <string name="pref_about_privacy_policy_key" translatable="false">PrivacyPolicy</string>
-    <string name="pref_about_privacy_policy_title">Privacy Policy</string>
+    <string name="pref_about_privacy_policy_title">מדיניות פרטיות</string>
     <string name="pref_privacy_enable_analytics_key" translatable="false">EnableAnalytics</string>
-    <string name="pref_privacy_enable_analytics_title">Share Analytics</string>
-    <string name="pref_privacy_enable_analytics_summary">With Google/Firebase Analytics</string>
+    <string name="pref_privacy_enable_analytics_title">שתף מידע אנונימי אודות השימוש שלך</string>
+    <string name="pref_privacy_enable_analytics_summary">Google/Firebase Analytics באמצעות</string>
     <string name="pref_privacy_enable_crash_tracking_key" translatable="false">EnableCrashTracking</string>
-    <string name="pref_privacy_enable_crash_tracking_title">Share Crash Information</string>
-    <string name="pref_privacy_enable_crash_tracking_summary">With Google Crashlytics</string>
+    <string name="pref_privacy_enable_crash_tracking_title">שתף מידע על התרסקות התוכנה</string>
+    <string name="pref_privacy_enable_crash_tracking_summary">Google Crashlyticsבאמצעות </string>
     <string name="pref_privacy_enable_ad_personalization_key" translatable="false">EnableAdPersonalization</string>
-    <string name="pref_privacy_enable_ad_personalization_title">Allow Ad Personalization</string>
-    <string name="pref_privacy_enable_ad_personalization_summary">With Google AdMob</string>
+    <string name="pref_privacy_enable_ad_personalization_title">אפשר התאמה אישית של פרסומות</string>
+    <string name="pref_privacy_enable_ad_personalization_summary">Google AdMobעם </string>
 
     <!-- =============== Preference Misc =================== -->
     <string name="pref_no_category_auto_backup_wifi_only_key" translatable="false">AutoBackupWifiOnly</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -40,8 +40,8 @@
     <string name="no">לא</string>
     <string name="pdf">PDF</string>
     <string name="report">דו״ח</string>
-    <string name="report_attached">דו״\ח 1 מצ״ב</string>
-    <string name="reports_attached">דו״\חות מצורפים %s</string>
+    <string name="report_attached">דוח 1 מצורף</string>
+    <string name="reports_attached">דוחות מצורפים %s</string>
     <string name="save">שמור</string>
     <string name="send_email">&#8230;שלח קובץ</string>
     <string name="submit">שלח</string>
@@ -78,12 +78,12 @@
     <string name="report_header_receipts_total_reimbursable">%s :סה״כ (זכאי להחזרים)</string>
     <string name="report_header_grand_total">%s :סה״כ</string>
     <string name="report_header_cost_center">%s :מרכז מחיר</string>
-    <string name="report_header_comment">%s :הערה לדו״\ח</string>
-    <string name="report_pdf_generation_error">שגיאה בייצור הדו״\ח</string>
+    <string name="report_header_comment">%s :הערה לדוח</string>
+    <string name="report_pdf_generation_error">שגיאה בייצור הדוח</string>
     <string name="report_pdf_error_too_many_columns_title">יותר מדי עמודות</string>
-	<string name="report_pdf_error_too_many_columns_message">.אין מספיק מקום ע״מ להכיל את כל העמודות בדו״\ח. אנא נסה להגביל את מספר העמודות בהגדרות</string>
+	<string name="report_pdf_error_too_many_columns_message">.אין מספיק מקום ע״מ להכיל את כל העמודות בדוח. אנא נסה להגביל את מספר העמודות בהגדרות</string>
 
-	<string name="report_pdf_error_too_many_columns_message_landscape">.אין מספיק מקום ע״מ להכיל את כל העמודות בדו״\ח. אנא נסה להגביל את מספר העמודות בהגדרות או עבור למצב מסך מאוזן</string>
+	<string name="report_pdf_error_too_many_columns_message_landscape">.אין מספיק מקום ע״מ להכיל את כל העמודות בדוח. אנא נסה להגביל את מספר העמודות בהגדרות או עבור למצב מסך מאוזן</string>
 	
     <string name="report_pdf_error_go_to_settings">עבור להגדרות</string>
 
@@ -166,11 +166,11 @@
     <string name="menu_receiptimage_rotate_cw">סובב עם כיוון השעון</string>
 
     <!-- ===================== Email ====================== -->
-    <string name="email_body_subject_5mb_warning">%s :הקובץ המצ״ב גדול מ-5 מגהבייט, ולכן ייתכן שלא יוצמד כראוי</string>
+    <string name="email_body_subject_5mb_warning">%s :הקובץ המצ\״ב גדול מ-5 מגהבייט, ולכן ייתכן שלא יוצמד כראוי</string>
 
     <!-- ============== Progress Messages ================= -->
     <string name="progress_import">מעלה את הקבצים שלך&#8230;</string>
-    <string name="progress_building_reports">...בונה דו״\חות</string>
+    <string name="progress_building_reports">...בונה דוחות</string>
 
     <!-- ============== Start Error Messages ================= -->
 	    <string name="SD_ERROR">.תקלה: אנא וודא שכרטיס הזכרון שלך זמין ולא מחובר למחשב שלך</string>
@@ -189,7 +189,7 @@
     <string name="MOVE_ERROR">תקלה: לא ניתן להזיז את הקבלה</string>
     <string name="COPY_ERROR">תקלה: לא ניתן להעתיק את הקבלה</string>
     <string name="toast_warning_reset_exchange_rate">אזהרה: שינוי המטבע יאתחל את כל המטבעות ושערי החליפין</string>
-    <string name="toast_error_trip_exists">תקלה: דו״\ח בשם הזה קיים כבר</string>
+    <string name="toast_error_trip_exists">תקלה: דוח בשם הזה קיים כבר</string>
     <string name="toast_error_category_exists">תקלה: קטגוריה בשם הזה קיימת כבר</string>
 
     <!-- ============== Toast Messages ================= -->
@@ -202,12 +202,14 @@
     <string name="toast_no_storage_permissions">לא ניתן לייבא קובץ בלי הרשאות לאחסון של הטלפון</string>
     <string name="toast_import_complete">.יובאו כל הקבצים בהצלחה. אנא אתחל את האפליקציה.</string>
     <string name="toast_reorder_hint"><![CDATA[לחץ לחיצה ארוכה על הפריט על מנת להתחיל גרירה]]></string>
-    <string name="toast_csv_report_distances">%s :על מנת ליצור דו״\ח אקסל אנא לחץ על</string>
+    <string name="toast_csv_report_distances">%s :על מנת ליצור דוח אקסל אנא לחץ על</string>
     <string name="attachment_error">Unable to attach this file.</string>
 
     <!-- ================== Trip Adapter ===================== -->
     <string name="trip_adapter_list_item_to">\u0020to\u0020</string>
     <string name="trip_no_data">You don\'t seem to have any reports defined at the moment. Try clicking the "+" (plus) button to get started.\n\nSmart Receipts lets you create Expense reports, track receipts within each, and quickly generate PDF &amp; CSV reports for your receipt totals. It\'s quick and easy! Also, be sure to check out the menu to customize the categories, reports, and other settings to best suit for your needs.</string>
+	<string name="trip_no_data">אין לך דו״ֿ\חות מוגדרים כרגע - נסה ללחוץ על כפתור ה״+״ ע״מ להוסיף ד/״.</string>
+	
 
     <!-- ================= Receipt Adapter =================== -->
     <string name="receipt_no_data">You don\'t seem to have any receipts yet. Try tapping the "+" (plus) button to get started&#8230;</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -317,81 +317,80 @@
     <!-- ===================== backup menu ======================== -->
     <string name="backups">גיבויים</string>
     <string name="manual_backup_title">גיבויים ידניים:</string>
-    <string name="manual_backup_description">Back up your data to keep your receipts safe! You can restore your data by importing the SmartReceipts.SMR backup file, which is generated via the "Backup" button below.</string>
-    <string name="manual_backup_export">Backup</string>
-    <string name="manual_backup_import">Import</string>
-    <string name="auto_backup_title">Automatic Backups [BETA]:</string>
-    <string name="auto_backup_wifi_only">Use Wi-Fi Only</string>
-    <string name="auto_backup_warning_none">Warning: Automatic backups are not configured!\nYou may be at risk of losing your data.</string>
-    <string name="auto_backup_warning_drive">Warning: Standard charges may apply for automatic backups over a mobile network.</string>
-    <string name="auto_backup_configure">Tap to Configure</string>
-    <string name="auto_backup_source_none">None</string>
+	<string name="manual_backup_description">גבה את המידע שלך על מנת לשמור על הקבולות שלך. אתה יכול לשחזר את המידע שלך על ידי ייבוא של קובץ הגיבוי, שנוצר על ידי כפתור ״\"גיבוי\" למטה.</string>
+    <string name="manual_backup_export">גיבוי</string>
+    <string name="manual_backup_import">ייבוא</string>
+    <string name="auto_backup_title">:גיבוי אוטומטי (ביטא)</string>
+    <string name="auto_backup_wifi_only">השתמש בווייפיי בלבד</string>
+    <string name="auto_backup_warning_none">זהירות: גיבויים אוטומטיים לא הוגדרו! אתה עלול לאבד את המידע שלך.</string>
+	    <string name="auto_backup_warning_drive">זהירות: אתה עלול להיות מחויב על ידי מפעיל הסלולר שלך על ידי יצירת גיבויים אוטומטיים ברשת הסלולרית.</string>
+    <string name="auto_backup_configure">לחץ להגדרות</string>
+    <string name="auto_backup_source_none">כלום</string>
     <string name="auto_backup_source_google_drive">Google Drive</string>
-    <string name="existing_backups_title">Existing Backups:</string>
-    <string name="existing_remote_backup_current_device">%s (Your Current Backup)</string>
-    <string name="remote_backups_list_item_menu_restore">Restore</string>
-    <string name="remote_backups_list_item_menu_delete">@string/delete</string>
-    <string name="remote_backups_list_item_menu_download_images">Download to ZIP</string>
-    <string name="remote_backups_list_item_menu_download_images_debug">[Debug] Download</string>
-
-    <string name="dialog_remote_backup_delete_title">@string/delete</string>
+    <string name="existing_backups_title">גיבויים קיימים</string>
+    <string name="existing_remote_backup_current_device">%s (הגיבוי הנוכחי שלך)</string>
+    <string name="remote_backups_list_item_menu_restore">שחזר</string>
+    <string name="remote_backups_list_item_menu_delete">@string/מחק</string>
+    <string name="remote_backups_list_item_menu_download_images">הורד כקובץ זיפ</string>
+    <string name="remote_backups_list_item_menu_download_images_debug">[Debug] הורד</string>
+    <string name="dialog_remote_backup_delete_title">@string/מחק</string>
     <string name="dialog_remote_backup_delete_message">Are you sure you wish to delete your backup from the %s device? This operation cannot be undone.</string>
-    <string name="dialog_remote_backup_delete_message_this_device">Are you sure you wish to delete your backup of this device? This operation cannot be undone. Please note that you may wish to turn off automatic backups after this operation completes or all local data may be re-synced.</string>
-    <string name="dialog_remote_backup_delete_positive">@string/delete</string>
-    <string name="dialog_remote_backup_delete_progress">Deleting your backup from the %s device&#8230;</string>
-    <string name="dialog_remote_backup_delete_toast_success">Successfully deleted this backup</string>
-    <string name="dialog_remote_backup_delete_toast_failure">Failed to delete this backup</string>
-    <string name="dialog_remote_backup_download_progress">Downloading images to ZIP File&#8230;</string>
+	  <string name="dialog_remote_backup_delete_message">אתה בטוח שאתה רוצה למחוק את הגיבויים שלך ממכשיר %s? פעולה זו הינה בלתי הפיכה.  </string>
+	    <string name="dialog_remote_backup_delete_message_this_device">אתה בטוח שאתה רוצה למחוק את הגיבוי שלך מהמכשיר הזה? הפעולה הינה בלתי הפיכה. אנא שים לב שרצוי לכבות את פונקציית הגיבויים האוטומטיים אחרי שהפעולה הזו הושלמה או שכל המידע המקומי עלול להיות מסונכרן שוב.</string>
+    <string name="dialog_remote_backup_delete_positive">@string/מחק</string>
+    <string name="dialog_remote_backup_delete_progress">מחק את הגיבוי שלך ממכשיר %s &#8230;</string>
+    <string name="dialog_remote_backup_delete_toast_success">הגיבוי נמחק בהצלחה</string>
+    <string name="dialog_remote_backup_delete_toast_failure">מחיקת הגיבוי נכשלה</string>
+    <string name="dialog_remote_backup_download_progress">מוריד קבצים לקובץ זיפ&#8230;</string>
+    <string name="dialog_remote_backup_drive_restore_title">שחזור דרייב</string>
+	    <string name="dialog_remote_backup_drive_restore_message">יש לנו בעיה עם סנכון המידע שלך. על מנת לטפל בנושא, נרצה למחוק את גיבוי הדרייב שלך ולסנכרן מחדש. אם אתה רואה את ההודעה הזו באופן קבוע, אנא צור קשר עם מפתח האפליקציה לתמיכה נוספת.</string>
+    <string name="dialog_remote_backup_restore_progress">מוחק את הגיבוי על מנת להתכונן לסנכרון מחדש&#8230;</string>
+    <string name="dialog_remote_backup_restore_toast_success">גיבוי נמחק בהצלחה. מסכנרן מחדש&#8230;</string>
+    <string name="dialog_remote_backup_restore_toast_failure">נכשל בסנכרון מחדש של הגיבוי</string>
 
-    <string name="dialog_remote_backup_drive_restore_title">Drive Restoration</string>
-    <string name="dialog_remote_backup_drive_restore_message">We\'re having trouble syncing your data. To recover, we\'d like to clear your Drive backup and re-sync. If you\'re seeing this message often, please reach out to us for further support.</string>
-    <string name="dialog_remote_backup_restore_progress">Clearing your backup to prepare for re-sync&#8230;</string>
-    <string name="dialog_remote_backup_restore_toast_success">Successfully cleared the backup. Re-syncing&#8230;</string>
-    <string name="dialog_remote_backup_restore_toast_failure">Failed to re-sync this backup</string>
+    <string name="automatic_backups_info_dialog_message">גיבויים אוטומטיים אינם מופעלים כרגע.</string>
+    <string name="automatic_backups_info_dialog_positive">לחץ להגדרות</string>
 
-    <string name="automatic_backups_info_dialog_message">Automatic backups are not currently enabled.</string>
-    <string name="automatic_backups_info_dialog_positive">Tap to Configure</string>
-
-    <string name="drive_sync_error_no_space">No Available Drive Storage Space</string>
-    <string name="drive_sync_error_no_permissions">Tap to Restore Drive Permissions</string>
-    <string name="drive_sync_error_lost_data">Drive Configuration Error - Tap to Fix</string>
+    <string name="drive_sync_error_no_space">אין מקום אחסון פנוי בדרייב</string>
+    <string name="drive_sync_error_no_permissions">לחץ לשחזור הרשאות בדרייב</string>
+    <string name="drive_sync_error_lost_data">טעות קונפיגורציה עם גוגל דרייב - לחץ לתיקון</string>
 
     <!-- ==============-========== Login ========================== -->
-    <string name="login_toolbar_title">Log In / Sign Up</string>
-    <string name="login_title">Log In with your Smart Receipts Account to start using Automatic Scans (OCR)</string>
-    <string name="login_field_email_hint">Email Address</string>
-    <string name="login_field_password_hint">Password</string>
-    <string name="sign_up_button_text">Sign Up</string>
-    <string name="login_button_text">Log In</string>
-    <string name="login_fields_hint_email">Please enter a valid email address:</string>
-    <string name="login_fields_hint_password">Passwords must be at least 8 characters:</string>
-    <string name="login_fields_hint_valid">Tap below to log in or sign up:</string>
-    <string name="login_success_toast">Login Success</string>
-    <string name="sign_up_success_toast">Sign Up Success</string>
-    <string name="login_failure_toast">Login Failed</string>
-    <string name="sign_up_failure_toast">Sign Up Failed</string>
-    <string name="login_failure_credentials_toast">Error: Incorrect Username or Password</string>
-    <string name="sign_up_failure_account_exists_toast">Error: This Email Already Exists - Try Logging In</string>
+    <string name="login_toolbar_title">התחבר / הירשם</string>
+    <string name="login_title">התחבר עם החשבון שלך על מנת להתחיל בסריקות אוטומטיות</string>
+    <string name="login_field_email_hint">דואר אלקטרוני</string>
+    <string name="login_field_password_hint">סיסמא</string>
+    <string name="sign_up_button_text">הירשם</string>
+    <string name="login_button_text">התחבר</string>
+    <string name="login_fields_hint_email">אנא הכנס כתובת דואר אלקטרוני תקינה:</string>
+    <string name="login_fields_hint_password">סיסמאות חייבות להיות בעלות 8 תווים לפחות:</string>
+    <string name="login_fields_hint_valid">לחץ למטה על מנת להתחבר או להירשם:</string>
+    <string name="login_success_toast">התחברות התבצעה בהצלחה</string>
+    <string name="sign_up_success_toast">הרשמה התבצעה בהצלחה</string>
+    <string name="login_failure_toast">התחברות נכשלה</string>
+    <string name="sign_up_failure_toast">הרשמה נכשלה</string>
+    <string name="login_failure_credentials_toast">שגיאה: שם משתמש או סיסמא לא נכונים</string>
+    <string name="sign_up_failure_account_exists_toast">שגיאה - כתובת הדואר האלקטורני קיימת כבר, נסה להתחבר</string>
 
     <!-- ==================== dialog filter ======================= -->
-    <string name="dialog_filter_positive_button">Add Filter</string>
-    <string name="dialog_filter_negative_button">Remove Filter</string>
+    <string name="dialog_filter_positive_button">הוסף פילור</string>
+    <string name="dialog_filter_negative_button">הסר פילטר</string>
 
     <!-- ==================== dialog miles ======================== -->
-    <string name="dialog_mileage_title_create">Add Distance</string>
-    <string name="dialog_mileage_title_update">Update Distance</string>
-    <string name="dialog_mileage_positive_create">Add</string>
-    <string name="dialog_mileage_positive_update">Update</string>
-    <string name="dialog_mileage_neutral_delete">Delete</string>
+    <string name="dialog_mileage_title_create">הוסף מרחק</string>
+    <string name="dialog_mileage_title_update">עדכן מרחק</string>
+    <string name="dialog_mileage_positive_create">הוסף</string>
+    <string name="dialog_mileage_positive_update">עדכן</string>
+    <string name="dialog_mileage_neutral_delete">מחק</string>
 
     <!-- ================= RECEIPTMENU_FIELDS =================== -->
-    <string name="RECEIPTMENU_FIELD_NAME">Name</string>
-    <string name="RECEIPTMENU_FIELD_PRICE">Price</string>
-    <string name="RECEIPTMENU_FIELD_TAX">Tax</string>
-    <string name="RECEIPTMENU_FIELD_CURRENCY">Currency</string>
-    <string name="RECEIPTMENU_FIELD_DATE">Date</string>
-    <string name="RECEIPTMENU_FIELD_CATEGORY">Category</string>
-    <string name="RECEIPTMENU_FIELD_COMMENT">Comment</string>
+    <string name="RECEIPTMENU_FIELD_NAME">שם</string>
+    <string name="RECEIPTMENU_FIELD_PRICE">מחיר</string>
+    <string name="RECEIPTMENU_FIELD_TAX">מס</string>
+    <string name="RECEIPTMENU_FIELD_CURRENCY">מטבע</string>
+    <string name="RECEIPTMENU_FIELD_DATE">תאריך</string>
+    <string name="RECEIPTMENU_FIELD_CATEGORY">קטגוריה</string>
+    <string name="RECEIPTMENU_FIELD_COMMENT">הערה</string>
     <string name="RECEIPTMENU_FIELD_EXTRA_EDITTEXT_1" />
     <string name="RECEIPTMENU_FIELD_EXTRA_EDITTEXT_2" />
     <string name="RECEIPTMENU_FIELD_EXTRA_EDITTEXT_3" />
@@ -403,8 +402,8 @@
 
     <!-- ============== Start String Arrays ================== -->
     <string-array name="EDIT_TRIP_ITEMS">
-        <item>Edit Report</item>
-        <item>Delete Report</item>
+        <item>ערוך דוח</item>
+        <item>מחק דוח</item>
     </string-array>
 
     <!-- ============== CSV/PDF Columns ================== -->

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -512,9 +512,9 @@
     <string name="apprating_dialog_positive">דרג עכשיו!</string>
 
     <!-- ================== Tooltip messages ==================== -->
-    <string name="tooltip_generate_info_message">Use the \'Generate\' tab to create your reports</string>
-    <string name="tooltip_backup_info_message">%d days since your last backup</string>
-    <string name="tooltip_no_backups_info_message">Reminder: Periodically back up your data</string>
+    <string name="tooltip_generate_info_message">השתמש בטאב הייצור על מנת ליצור את הדוחות שלך</string>
+    <string name="tooltip_backup_info_message">%d ימים מאז הגיבוי האחרון שלך</string>
+    <string name="tooltip_no_backups_info_message">תזכורת: גבה את המידע שלך באופן קבוע</string>
     <string name="tooltip_import_info_message">Please, choose receipt for your attachment</string>
     <string name="tooltip_review_privacy">Tap to review your privacy settings</string>
 

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -1,0 +1,528 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- =================== App Details ===================== -->
+    <string name="app_name">Smart Receipts</string>
+
+
+    <!-- ================ Main Menu Options ================== -->
+    <string name="menu_main_settings">הגדרות</string>
+    <string name="menu_main_categories">קטגוריות</string>
+    <string name="menu_main_csv">CSV התאם אישית פלט </string>
+    <string name="menu_main_pdf">PDF התאם אישית פלט </string>
+    <string name="menu_main_ocr_configuration">(OCR) סריקות אוטומטיות</string>
+    <string name="menu_main_export">גיבוי</string>
+
+    <!-- ================ General Strings ================== -->
+    <string name="add">הוסף</string>
+    <string name="reorder">שנה סדר</string>
+    <string name="column_item">%s עמודה</string>
+    <string name="copy">העתק</string>
+    <string name="daily_total">%s :סה״כ יומי</string>
+    <string name="day">יום %s</string>
+    <string name="days">ימים %s</string>
+    <string name="delete">מחק</string>
+    <string name="delete_item">?%s מחק</string>
+    <string name="delete_sync_information">כל מידע מסונכרן לענן על הפריט הזה יימחק גם הוא.</string>
+    <string name="distance">מרחק</string>
+    <string name="distance_total_item">%s :סה״כ מרחק</string>
+    <string name="edit">ערוך</string>
+    <string name="export">ייצא</string>
+    <string name="feedback">משוב - %s</string>
+    <string name="image">תמונה</string>
+    <string name="import_string">ייבא</string>
+    <string name="import_string_item">%s ייבא</string>
+    <string name="item_code">:קוד</string>
+    <string name="item_name">:שם</string>
+    <string name="move">הזז</string>
+    <string name="move_copy_item">?%s הזז/העתק את</string>
+    <string name="next_id">%s :המזהה הבא</string>
+    <string name="no">לא</string>
+    <string name="pdf">PDF</string>
+    <string name="report">דו״ח</string>
+    <string name="report_attached">דו״ח 1 מצ״ב</string>
+    <string name="reports_attached">דו״חות מצורפים %s</string>
+    <string name="save">שמור</string>
+    <string name="send_email">&#8230;שלח קובץ</string>
+    <string name="submit">שלח</string>
+    <string name="support">תמיכה - %s</string>
+    <string name="total">סה״כ</string>
+    <string name="undefined">לא מוגדר</string>
+    <string name="update">עדכן</string>
+    <string name="yes">כן</string>
+    <string name="yes_as_pdf">PDF כן - בתור</string>
+    <string name="share">שתף</string>
+
+    <!-- =============== Subscriptions ================ -->
+    <string name="pro_subscription">Smart Receipts Plus</string>
+
+    <!-- ============= Subscription Info ============== -->
+
+    <!-- ================ No More Ads ================= -->
+    <string name="missing_ad_suggest_removal_upsell">נמאס לך מפרסומות? לחץ להתחלת תקופת נסיון ללא פרסומות</string>
+
+    <!-- ============= Report Navigation ============== -->
+    <string name="report_info_graphs">גרפים</string>
+    <string name="report_info_receipts">קבלות</string>
+    <string name="report_info_distance">מרחק</string>
+    <string name="report_info_generate">ייצר</string>
+
+    <!-- ============= Report Generation ============== -->
+    <string name="report_header_from">%s :מאת</string>
+    <string name="report_header_to">%s :אל</string>
+    <string name="report_header_receipts_total">%s :סה״כ קבלות</string>
+    <string name="report_header_receipts_total_tax">%s :סה״כ מס</string>
+    <string name="report_header_receipts_total_no_tax">%s :סה״כ קבלות (ללא מס)</string>
+    <string name="report_header_receipts_total_with_tax">%s :סה״כ קבלות (עם מס)</string>
+    <string name="report_header_distance_total">%s :סה״כ מרחק</string>
+    <string name="report_header_receipts_total_reimbursable">%s :סה״כ (זכאי להחזרים)</string>
+    <string name="report_header_grand_total">%s :סה״כ</string>
+    <string name="report_header_cost_center">%s :מרכז מחיר</string>
+    <string name="report_header_comment">%s :הערה לדו״ח</string>
+    <string name="report_pdf_generation_error">שגיאה בייצור הדו״ח</string>
+    <string name="report_pdf_error_too_many_columns_title">יותר מדי עמודות</string>
+	<string name="report_pdf_error_too_many_columns_message">.אין מספיק מקום ע״מ להכיל את כל העמודות בדו״ח. אנא נסה להגביל את מספר העמודות בהגדרות</string>
+
+	<string name="report_pdf_error_too_many_columns_message_landscape">.אין מספיק מקום ע״מ להכיל את כל העמודות בדו״ח. אנא נסה להגביל את מספר העמודות בהגדרות או עבור למצב מסך מאוזן</string>
+	
+    <string name="report_pdf_error_go_to_settings">עבור להגדרות</string>
+
+    <!-- ===================== ocr ======================== -->
+    <string name="ocr_informational_tooltip_configure_text">(רשות) רוצה להגדיר סריקות אוטומטיות? לחץ כאן</string>
+    <plurals name="ocr_informational_tooltip_limited_scans_text">
+        <item quantity="one">.סריקה נותרה. לחץ ליותר %d</item>
+        <item quantity="other">.סריקות נותרו. לחץ ליותר %d</item>
+    </plurals>
+    <string name="ocr_status_title">:OCR מבצע סריקת</string>
+    <string name="ocr_status_message_uploading_image">&#8230;מעלה קבלה</string>
+    <string name="ocr_status_message_performing_scan">סורק עבור מטא-דאטה של קבלה&#8230;</string>
+    <string name="ocr_status_message_fetching_results">מביא תוצאות&#8230;</string>
+    <string name="ocr_configuration_title">(OCR) סריקות אוטומטיות</string>
+    <string name="ocr_configuration_scans_remaining">%d :שנותרו (OCR) סריקות אוטומטיות</string>
+    <string name="ocr_configuration_my_account">%s</string>
+    <string name="ocr_configuration_welcome">(OCR) סריקות אוטומטיות</string>
+	    <string name="ocr_configuration_information">Smart Receipts has integrated with Taggun to provide automatic scanning (ie OCR) services, which can extract receipt metadata like the price, tax, date, and merchant name from your photos.</string>
+    <string name="ocr_configuration_information_line2">We use a combination of Google Vision and Machine Learning to quickly (often in 5 seconds or less) deliver results, which will become increasingly accurate over time. Since these services have a per-usage charge, we will charge for each receipt scan below.</string>
+    <string name="ocr_is_enabled">?(OCR) הפעל סריקות אוטומטיות</string>
+    <string name="ocr_save_scans_to_improve_results">?אפשר לנו לשמור תמונות על מנת לשפר את התוצאות</string>
+    <string name="ocr_configuration_available_purchases">:רכישות אפשריות - לחץ לקנות</string>
+    <string name="ocr_configuration_information_line3">To try OCR, all new users get 2 free scans! Please remember that OCR is an optional feature and can be disabled at any time.</string>
+
+    <!-- ================ Categories ================== -->
+    <string name="category_name"> :שם</string>
+    <string name="category_code"> :קוד</string>
+    <string name="category_null">&lt;קטגוריה&gt;</string>
+    <string name="category_null_code">NUL</string>
+    <string name="category_airfare">טיסות</string>
+    <string name="category_airfare_code">AIRP</string>
+    <string name="category_breakfast">ארוחת בוקר</string>
+    <string name="category_breakfast_code">BRFT</string>
+    <string name="category_dinner">ארוחת ערב</string>
+    <string name="category_dinner_code">DINN</string>
+    <string name="category_entertainment">בידור</string>
+    <string name="category_entertainment_code">ENT</string>
+    <string name="category_gasoline">Gasoline</string>
+    <string name="category_gasoline_code">GAS</string>
+    <string name="category_gift">Gift</string>
+    <string name="category_gift_code">GIFT</string>
+    <string name="category_hotel">Hotel</string>
+    <string name="category_hotel_code">HTL</string>
+    <string name="category_laundry">Laundry</string>
+    <string name="category_laundry_code">LAUN</string>
+    <string name="category_lunch">Lunch</string>
+    <string name="category_lunch_code">LNCH</string>
+    <string name="category_other">Other</string>
+    <string name="category_other_code">MISC</string>
+    <string name="category_parking_tolls">Parking/Tolls</string>
+    <string name="category_parking_tolls_code">PARK</string>
+    <string name="category_postage_shipping">Postage/Shipping</string>
+    <string name="category_postage_shipping_code">POST</string>
+    <string name="category_car_rental">Car Rental</string>
+    <string name="category_car_rental_code">RCAR</string>
+    <string name="category_taxi_bus">Taxi/Bus</string>
+    <string name="category_taxi_bus_code">TAXI</string>
+    <string name="category_telephone_fax">Telephone/Fax</string>
+    <string name="category_telephone_fax_code">TELE</string>
+    <string name="category_tip">Tip</string>
+    <string name="category_tip_code">TIP</string>
+    <string name="category_train">Train</string>
+    <string name="category_train_code">TRN</string>
+    <string name="category_books_periodicals">Books/Periodicals</string>
+    <string name="category_books_periodicals_code">ZBKP</string>
+    <string name="category_cell_phone">Cell Phone</string>
+    <string name="category_cell_phone_code">ZCEL</string>
+    <string name="category_dues_subscriptions">Dues/Subscriptions</string>
+    <string name="category_dues_subscriptions_code">ZDUE</string>
+    <string name="category_meals_justified">Meals (Justified)</string>
+    <string name="category_meals_justified_code">ZMEO</string>
+    <string name="category_stationery_stations">Stations</string>
+    <string name="category_stationery_stations_code">ZSTS</string>
+    <string name="category_training_fees">Training Fees</string>
+    <string name="category_training_fees_code">ZTRN</string>
+
+    <!-- ================ Img Menu Options =================== -->
+    <string name="menu_receiptimage_retake">Retake Photo</string>
+    <string name="menu_receiptimage_rotate_ccw">Rotate CCW</string>
+    <string name="menu_receiptimage_rotate_cw">Rotate CW</string>
+
+    <!-- ===================== Email ====================== -->
+    <string name="email_body_subject_5mb_warning">The following attachment is over 5MB in size and may not properly attach: %s</string>
+
+    <!-- ============== Progress Messages ================= -->
+    <string name="progress_import">Importing your files&#8230;</string>
+    <string name="progress_building_reports">Building Reports…</string>
+
+    <!-- ============== Start Error Messages ================= -->
+    <string name="SD_ERROR">Error: Please make sure that your SD Card is available and not mounted to your computer.</string>
+    <string name="SD_WARNING">Warning: Your SD Card is not available or is mounted to your computer. Some images may be inaccessible. Switching to internal storage&#8230;</string>
+    <string name="database_error">Error: Failed to save your receipt</string>
+    <string name="database_get_error">Error: Failed to fetch your data. Try re-launching the app.</string>
+    <string name="IMG_OPEN_ERROR">Error: The image is currently inaccessible or corrupted. Your SD Card may be unavailable or mounted to your computer. If not, click the menu button to retake the photo.</string>
+    <string name="IMG_SAVE_ERROR">Error: The Image Failed to Save Properly</string>
+    <string name="FILE_SAVE_ERROR">Error: The File Failed to Save Properly</string>
+    <string name="ILLEGAL_CHAR_ERROR">Error: The name contains an illegal character</string>
+    <string name="SPACE_ERROR">Error: The name cannot begin with a space</string>
+    <string name="CALENDAR_TAB_ERROR">Error: Please Touch the Date TextBox to set the Date</string>
+    <string name="DURATION_ERROR">Error: The Start Date Must Occur Prior To The End Date</string>
+    <string name="EXPORT_ERROR">Error: Failed to properly export your data.</string>
+    <string name="IMPORT_ERROR">Error: Failed to recognize the file as importable</string>
+    <string name="MOVE_ERROR">Error: Failed to move the receipt</string>
+    <string name="COPY_ERROR">Error: Failed to copy the receipt</string>
+    <string name="toast_warning_reset_exchange_rate">Warning: Changing the currency will reset ALL exchange rates</string>
+    <string name="toast_error_trip_exists">Error: An expense report with that name already exists</string>
+    <string name="toast_error_category_exists">Error: An category with that name already exists</string>
+
+    <!-- ============== Toast Messages ================= -->
+    <string name="toast_receipt_copy">Successfully copied the receipt</string>
+    <string name="toast_receipt_move">Successfully moved the receipt</string>
+    <string name="toast_receipt_image_added">Successfully added a new image to %s</string>
+    <string name="toast_receipt_image_replaced">Successfully replaced a new image for %s</string>
+    <string name="toast_receipt_pdf_added">Successfully added a new PDF to %s</string>
+    <string name="toast_receipt_pdf_replaced">Successfully replaced a new PDF for %s</string>
+    <string name="toast_no_storage_permissions">Cannot import file without storage permissions</string>
+    <string name="toast_import_complete">Successfully imported all files. Please re-launch the app.</string>
+    <string name="toast_reorder_hint"><![CDATA[Long press item to initiate dragging]]></string>
+    <string name="toast_csv_report_distances">To create CSV report please check option %s</string>
+    <string name="attachment_error">Unable to attach this file.</string>
+
+    <!-- ================== Trip Adapter ===================== -->
+    <string name="trip_adapter_list_item_to">\u0020to\u0020</string>
+    <string name="trip_no_data">You don\'t seem to have any reports defined at the moment. Try clicking the "+" (plus) button to get started.\n\nSmart Receipts lets you create Expense reports, track receipts within each, and quickly generate PDF &amp; CSV reports for your receipt totals. It\'s quick and easy! Also, be sure to check out the menu to customize the categories, reports, and other settings to best suit for your needs.</string>
+
+    <!-- ================= Receipt Adapter =================== -->
+    <string name="receipt_no_data">You don\'t seem to have any receipts yet. Try tapping the "+" (plus) button to get started&#8230;</string>
+
+    <!-- ================= Distance Adapter ================== -->
+    <string name="distance_no_data">You don\'t seem to have any distance tracked yet. Try clicking the "+" (plus) button to get started.</string>
+    <string name="distance_insert_failed">Error: Failed to create this distance item. Please make sure your phone is not mounted to your computer.</string>
+    <string name="distance_update_failed">Error: Failed to update this distance item. Please make sure your phone is not mounted to your computer.</string>
+    <string name="distance_delete_failed">Error: Failed to delete this distance item. Please make sure your phone is not mounted to your computer.</string>
+
+    <!-- ================= Trip Actions =================== -->
+
+    <!-- ================= Receipt Actions =================== -->
+    <string name="receipt_action_camera">Picture</string>
+    <string name="receipt_action_text">Text-Only</string>
+    <string name="receipt_action_import">Import</string>
+
+    <!-- ==================== Cards ========================= -->
+
+    <!-- ================ DIALOG (GENERAL) =================== -->
+    <string name="DIALOG_CANCEL">Cancel</string>
+
+    <!-- ================= DIALOG_WELCOME ==================== -->
+
+    <!-- ================== DIALOG_EMAIL ===================== -->
+    <string name="DIALOG_EMAIL_CHECKBOX_PDF_FULL">Full PDF Report</string>
+    <string name="DIALOG_EMAIL_CHECKBOX_PDF_IMAGES">PDF Report - No Table</string>
+    <string name="DIALOG_EMAIL_CHECKBOX_CSV">CSV File</string>
+    <string name="DIALOG_EMAIL_CHECKBOX_ZIP_WITH_METADATA">ZIP - Receipt Files with Metadata</string>
+    <string name="DIALOG_EMAIL_CHECKBOX_ZIP">ZIP - Receipts Files</string>
+    <string name="DIALOG_EMAIL_TOAST_NO_SELECTION">Please Check At Least One Report</string>
+    <string name="DIALOG_EMAIL_TOAST_NO_RECEIPTS">There are No Receipts in this Report</string>
+    <string name="generate_report_tooltip">Tap to configure the report layouts</string>
+
+
+    <!-- ================= DIALOG_SETTINGS =================== -->
+
+
+    <!-- ================= DIALOG_TRIPMENU =================== -->
+    <string name="DIALOG_TRIPMENU_HINT_NAME">Name</string>
+    <string name="DIALOG_TRIPMENU_HINT_START">Start Date</string>
+    <string name="DIALOG_TRIPMENU_HINT_END">End Date</string>
+    <string name="DIALOG_TRIPMENU_TITLE_NEW">New Expense Report</string>
+    <string name="DIALOG_TRIPMENU_TITLE_EDIT">Edit Report</string>
+    <string name="DIALOG_TRIPMENU_TOAST_MISSING_FIELD">Please Fill Out All Fields</string>
+
+    <!-- =============== DIALOG_TRIP_DELETE ================== -->
+    <string name="DIALOG_TRIP_DELETE_POSITIVE_BUTTON">Delete</string>
+
+    <!-- ================= DIALOG_RECEIPTMENU =================== -->
+    <string name="DIALOG_RECEIPTMENU_HINT_NAME">Name</string>
+    <string name="DIALOG_RECEIPTMENU_HINT_PRICE">Price (e.g. 150.00)</string>
+    <string name="DIALOG_RECEIPTMENU_HINT_PRICE_SHORT">Price</string>
+    <string name="DIALOG_RECEIPTMENU_HINT_TAX">Tax</string>
+    <string name="DIALOG_RECEIPTMENU_HINT_CURRENCY">Currency</string>
+    <string name="DIALOG_RECEIPTMENU_HINT_EXCHANGE_RATE">Exchange Rate</string>
+    <string name="DIALOG_RECEIPTMENU_HINT_EXCHANGE_RATE_FAILED">Exchange Rate Failed. Retry?</string>
+    <string name="receipt_input_exchanged_result_hint">Base Currency Price</string>
+    <string name="DIALOG_RECEIPTMENU_HINT_DATE">Date</string>
+    <string name="DIALOG_RECEIPTMENU_HINT_CATEGORY">Category</string>
+    <string name="DIALOG_RECEIPTMENU_HINT_COMMENT">Comment</string>
+    <string name="DIALOG_RECEIPTMENU_HINT_COST_CENTER">Cost Center</string>
+    <string name="DIALOG_RECEIPTMENU_HINT_EXPENSABLE">Reimbursable?</string>
+    <string name="DIALOG_RECEIPTMENU_HINT_FULLPAGE"> Full-Page Image?</string>
+    <string name="DIALOG_RECEIPTMENU_TITLE_NEW">New Receipt</string>
+    <string name="DIALOG_RECEIPTMENU_TITLE_NEW_ID">New Receipt - %s</string>
+    <string name="DIALOG_RECEIPTMENU_TITLE_EDIT">Edit Receipt</string>
+    <string name="DIALOG_RECEIPTMENU_TITLE_EDIT_ID">Edit Receipt - %s</string>
+    <string name="DIALOG_RECEIPTMENU_TOAST_BAD_DATE">Warning: This Receipt\'s Date falls outside the specified range for this Report</string>
+    <string name="manage_categories">Manage Categories</string>
+    <string name="manage_payment_methods">Manage Payment Methods</string>
+
+    <!-- ================= DIALOG_RECEIPT_ATTACHMENT =================== -->
+    <string name="receipt_attach_photo">Take a photo</string>
+    <string name="receipt_attach_image">Pick a photo</string>
+    <string name="receipt_attach_file">Attach file</string>
+
+
+    <!-- ==================== dialog export / import ====================== -->
+    <string name="dialog_export_title">Export your receipts?</string>
+    <string name="dialog_export_text">You can reimport your data by clicking on the SmartReceipts.SMR file, which is generated by clicking below.</string>
+    <string name="dialog_export_positive">Export</string>
+    <string name="dialog_import_positive">Import</string>
+    <string name="dialog_import_text">Overwrite All Existing Data</string>
+    <string name="dialog_export_working">Exporting your receipts&#8230;</string>
+
+    <!-- ==================== DIALOG_ABOUT ====================== -->
+
+    <!-- ====================== Distance Report ======================== -->
+    <string name="distance_location_field">Location</string>
+    <string name="distance_price_field">Price</string>
+    <string name="distance_distance_field">Distance</string>
+    <string name="distance_rate_field">Rate</string>
+    <string name="dialog_currency_field">Currency</string>
+    <string name="distance_date_field">Date</string>
+    <string name="distance_comment_field">Comment</string>
+
+    <!-- ====================== Categories Summation Report ======================== -->
+    <string name="category_name_field">Category</string>
+    <string name="category_code_field">Category Code</string>
+    <string name="category_price_field">Price</string>
+    <string name="category_tax_field">Tax</string>
+    <string name="category_currency_field">Currency</string>
+
+    <!-- ===================== backup menu ======================== -->
+    <string name="backups">Backups</string>
+    <string name="manual_backup_title">Manual Backups:</string>
+    <string name="manual_backup_description">Back up your data to keep your receipts safe! You can restore your data by importing the SmartReceipts.SMR backup file, which is generated via the "Backup" button below.</string>
+    <string name="manual_backup_export">Backup</string>
+    <string name="manual_backup_import">Import</string>
+    <string name="auto_backup_title">Automatic Backups [BETA]:</string>
+    <string name="auto_backup_wifi_only">Use Wi-Fi Only</string>
+    <string name="auto_backup_warning_none">Warning: Automatic backups are not configured!\nYou may be at risk of losing your data.</string>
+    <string name="auto_backup_warning_drive">Warning: Standard charges may apply for automatic backups over a mobile network.</string>
+    <string name="auto_backup_configure">Tap to Configure</string>
+    <string name="auto_backup_source_none">None</string>
+    <string name="auto_backup_source_google_drive">Google Drive</string>
+    <string name="existing_backups_title">Existing Backups:</string>
+    <string name="existing_remote_backup_current_device">%s (Your Current Backup)</string>
+    <string name="remote_backups_list_item_menu_restore">Restore</string>
+    <string name="remote_backups_list_item_menu_delete">@string/delete</string>
+    <string name="remote_backups_list_item_menu_download_images">Download to ZIP</string>
+    <string name="remote_backups_list_item_menu_download_images_debug">[Debug] Download</string>
+
+    <string name="dialog_remote_backup_delete_title">@string/delete</string>
+    <string name="dialog_remote_backup_delete_message">Are you sure you wish to delete your backup from the %s device? This operation cannot be undone.</string>
+    <string name="dialog_remote_backup_delete_message_this_device">Are you sure you wish to delete your backup of this device? This operation cannot be undone. Please note that you may wish to turn off automatic backups after this operation completes or all local data may be re-synced.</string>
+    <string name="dialog_remote_backup_delete_positive">@string/delete</string>
+    <string name="dialog_remote_backup_delete_progress">Deleting your backup from the %s device&#8230;</string>
+    <string name="dialog_remote_backup_delete_toast_success">Successfully deleted this backup</string>
+    <string name="dialog_remote_backup_delete_toast_failure">Failed to delete this backup</string>
+    <string name="dialog_remote_backup_download_progress">Downloading images to ZIP File&#8230;</string>
+
+    <string name="dialog_remote_backup_drive_restore_title">Drive Restoration</string>
+    <string name="dialog_remote_backup_drive_restore_message">We\'re having trouble syncing your data. To recover, we\'d like to clear your Drive backup and re-sync. If you\'re seeing this message often, please reach out to us for further support.</string>
+    <string name="dialog_remote_backup_restore_progress">Clearing your backup to prepare for re-sync&#8230;</string>
+    <string name="dialog_remote_backup_restore_toast_success">Successfully cleared the backup. Re-syncing&#8230;</string>
+    <string name="dialog_remote_backup_restore_toast_failure">Failed to re-sync this backup</string>
+
+    <string name="automatic_backups_info_dialog_message">Automatic backups are not currently enabled.</string>
+    <string name="automatic_backups_info_dialog_positive">Tap to Configure</string>
+
+    <string name="drive_sync_error_no_space">No Available Drive Storage Space</string>
+    <string name="drive_sync_error_no_permissions">Tap to Restore Drive Permissions</string>
+    <string name="drive_sync_error_lost_data">Drive Configuration Error - Tap to Fix</string>
+
+    <!-- ==============-========== Login ========================== -->
+    <string name="login_toolbar_title">Log In / Sign Up</string>
+    <string name="login_title">Log In with your Smart Receipts Account to start using Automatic Scans (OCR)</string>
+    <string name="login_field_email_hint">Email Address</string>
+    <string name="login_field_password_hint">Password</string>
+    <string name="sign_up_button_text">Sign Up</string>
+    <string name="login_button_text">Log In</string>
+    <string name="login_fields_hint_email">Please enter a valid email address:</string>
+    <string name="login_fields_hint_password">Passwords must be at least 8 characters:</string>
+    <string name="login_fields_hint_valid">Tap below to log in or sign up:</string>
+    <string name="login_success_toast">Login Success</string>
+    <string name="sign_up_success_toast">Sign Up Success</string>
+    <string name="login_failure_toast">Login Failed</string>
+    <string name="sign_up_failure_toast">Sign Up Failed</string>
+    <string name="login_failure_credentials_toast">Error: Incorrect Username or Password</string>
+    <string name="sign_up_failure_account_exists_toast">Error: This Email Already Exists - Try Logging In</string>
+
+    <!-- ==================== dialog filter ======================= -->
+    <string name="dialog_filter_positive_button">Add Filter</string>
+    <string name="dialog_filter_negative_button">Remove Filter</string>
+
+    <!-- ==================== dialog miles ======================== -->
+    <string name="dialog_mileage_title_create">Add Distance</string>
+    <string name="dialog_mileage_title_update">Update Distance</string>
+    <string name="dialog_mileage_positive_create">Add</string>
+    <string name="dialog_mileage_positive_update">Update</string>
+    <string name="dialog_mileage_neutral_delete">Delete</string>
+
+    <!-- ================= RECEIPTMENU_FIELDS =================== -->
+    <string name="RECEIPTMENU_FIELD_NAME">Name</string>
+    <string name="RECEIPTMENU_FIELD_PRICE">Price</string>
+    <string name="RECEIPTMENU_FIELD_TAX">Tax</string>
+    <string name="RECEIPTMENU_FIELD_CURRENCY">Currency</string>
+    <string name="RECEIPTMENU_FIELD_DATE">Date</string>
+    <string name="RECEIPTMENU_FIELD_CATEGORY">Category</string>
+    <string name="RECEIPTMENU_FIELD_COMMENT">Comment</string>
+    <string name="RECEIPTMENU_FIELD_EXTRA_EDITTEXT_1" />
+    <string name="RECEIPTMENU_FIELD_EXTRA_EDITTEXT_2" />
+    <string name="RECEIPTMENU_FIELD_EXTRA_EDITTEXT_3" />
+
+    <!-- ================== RECEIPTMENU_TAGS ==================== -->
+    <string name="RECEIPTMENU_TAG_EXTRA_EDITTEXT_1">extra_edittext_1</string>
+    <string name="RECEIPTMENU_TAG_EXTRA_EDITTEXT_2">extra_edittext_2</string>
+    <string name="RECEIPTMENU_TAG_EXTRA_EDITTEXT_3">extra_edittext_3</string>
+
+    <!-- ============== Start String Arrays ================== -->
+    <string-array name="EDIT_TRIP_ITEMS">
+        <item>Edit Report</item>
+        <item>Delete Report</item>
+    </string-array>
+
+    <!-- ============== CSV/PDF Columns ================== -->
+    <string name="column_item_blank">Blank Column</string>
+    <string name="column_item_category_code">Category Code</string>
+    <string name="column_item_category_name">Category Name</string>
+    <string name="column_item_user_id">User ID</string>
+    <string name="column_item_report_name">Report Name</string>
+    <string name="column_item_report_start_date">Report Start Date</string>
+    <string name="column_item_report_end_date">Report End Date</string>
+    <string name="column_item_report_comment">Report Comment</string>
+    <string name="column_item_report_cost_center">Report Cost Center</string>
+    <string name="column_item_image_file_name">Image Name</string>
+    <string name="column_item_image_path">Image Path</string>
+    <!-- **Please note that for flex purposes, some of these use the legacy names above** -->
+    <string name="column_item_receipt_price_minus_tax">Price Minus Tax</string>
+    <string name="column_item_converted_price_exchange_rate">Price (Exchanged)</string>
+    <string name="column_item_converted_tax_exchange_rate">Tax (Exchanged)</string>
+    <string name="column_item_converted_price_plus_tax_exchange_rate">Price Plus Tax (Exchanged)</string>
+    <string name="column_item_converted_price_minus_tax_exchange_rate">Price Minus Tax (Exchanged)</string>
+    <string name="column_item_exchange_rate">Exchange Rate</string>
+    <string name="column_item_pictured">Pictured</string>
+    <string name="column_item_reimbursable">Reimbursable</string>
+    <string name="column_item_deprecated_expensable" translatable="false">Expensable</string>
+    <string name="column_item_index">Receipt Index</string>
+    <string name="column_item_id">Receipt ID</string>
+    <string name="column_item_payment_method">Payment Method</string>
+
+    <string name="receipt_dialog_action_edit">Edit Receipt</string>
+    <string name="receipt_dialog_action_view">View Receipt %s</string>
+    <string name="receipt_dialog_action_delete">Delete Receipt</string>
+    <string name="receipt_dialog_action_move_copy">Move/Copy</string>
+    <string name="receipt_dialog_action_remove_attachment">Remove Attachment</string>
+
+    <string name="dialog_attachment_text">Tap on an existing receipt to add this %s to it</string>
+    <string name="receipt_dialog_remove_attachment">Do you want to remove attachment?</string>
+
+    <!-- ================== Preference Dialog ==================== -->
+    <string name="dialog_custom_csv_spinner">Column Type</string>
+    <string name="dialog_category_add">Add Category</string>
+    <string name="dialog_category_edit">Edit Category</string>
+
+    <!-- ================ Error Feedback ==================== -->
+    <string name="error_no_pdf_activity_viewer">Failed to find a PDF Viewer Application</string>
+    <string name="error_no_send_intent_dialog_title">No Send App Found</string>
+    <string name="error_no_send_intent_dialog_message">We could not find an email application (or equivalent) on your phone. You can find your files in the following directory: %s</string>
+    <string name="error_no_file_intent_dialog_title">Error: Unable to find an "import" installed app on your device</string>
+    <string name="error_no_wifi">Error: Not connected to WiFi</string>
+
+    <!-- ================== ActionBar ===================== -->
+
+    <!-- ================== CSV Table ===================== -->
+
+    <!-- ================== Legacy Camera ==================== -->
+
+    <!-- ================== SQL Corrpution ==================== -->
+    <string name="dialog_sql_corrupt_title">Oh No!</string>
+    <string name="dialog_sql_corrupt_message">Your database was corrupted. This often occurs if you have a task killer app, but it can be caused by a few different things. Don\'t worry, we should be able to restore most of your data.</string>
+    <string name="dialog_sql_corrupt_positive">Email the Developer for Help</string>
+    <string name="dialog_sql_corrupt_intent_subject">Smart Receipts - Corrupted Database</string>
+    <string name="dialog_sql_corrupt_intent_text">Help - my database was corrupted. How can you help me restore things?</string>
+    <string name="dialog_sql_corrupt_chooser">Send Email&#8230;</string>
+
+    <!-- ======================= Filters ====================== -->
+    <string name="filter_name_and">And</string>
+    <string name="filter_name_not">Not</string>
+    <string name="filter_name_or">Or</string>
+    <string name="filter_name_receipt_category">Category</string>
+    <string name="filter_name_receipt_reimbursable">Is Reimbursable</string>
+    <string name="filter_name_receipt_max_price">Max Price</string>
+    <string name="filter_name_receipt_min_price">Min Price</string>
+    <string name="filter_name_receipt_on_or_after">On Or After</string>
+    <string name="filter_name_receipt_on_or_before">On Or Before</string>
+    <string name="filter_name_receipt_selected">Is Selected</string>
+    <string name="filter_name_trip_ends_on_or_after">Ends On Or After</string>
+    <string name="filter_name_trip_ends_on_or_before">Ends On Or Before</string>
+    <string name="filter_name_trip_max_price">Max Price</string>
+    <string name="filter_name_trip_min_price">Min Price</string>
+    <string name="filter_name_trip_starts_on_or_after">Starts On Or After</string>
+    <string name="filter_name_trip_starts_on_or_before">Starts On Or Before</string>
+
+    <!-- =================== Payment Methods =====+============= -->
+    <string name="payment_method">Payment Method</string>
+    <string name="payment_methods">Payment Methods</string>
+    <string name="payment_method_add">Add Payment Method</string>
+    <string name="payment_method_edit">Edit Payment Method</string>
+    <string name="payment_method_default_cash">Cash</string>
+    <string name="payment_method_default_check">Check</string>
+    <string name="payment_method_default_personal_card">Personal Card</string>
+    <string name="payment_method_default_corporate_card">Corporate Card</string>
+
+    <!-- =================== Payment Methods =================== -->
+    <string name="purchase_succeeded">Successfully completed the purchase</string>
+    <string name="purchase_unavailable">Unable to retrieve purchase information</string>
+    <string name="purchase_failed">Failed to complete the purchase</string>
+
+    <!-- ================== App Rating ==================== -->
+    <string name="rating_tooltip_text">Like Smart Receipts?</string>
+    <string name="leave_feedback_text">Would you like to leave us feedback?</string>
+    <string name="apprating_dialog_title">Like %s?</string>
+    <string name="apprating_dialog_message">Please consider leaving a review about it. As an independent developer, your reviews are my primary source of exposure and really help to encourage me to keep adding new features. Thanks!</string>
+    <string name="apprating_dialog_negative">No Thanks</string>
+    <string name="apprating_dialog_neutral">Maybe Later</string>
+    <string name="apprating_dialog_positive">Rate It Now!</string>
+
+    <!-- ================== Tooltip messages ==================== -->
+    <string name="tooltip_generate_info_message">Use the \'Generate\' tab to create your reports</string>
+    <string name="tooltip_backup_info_message">%d days since your last backup</string>
+    <string name="tooltip_no_backups_info_message">Reminder: Periodically back up your data</string>
+    <string name="tooltip_import_info_message">Please, choose receipt for your attachment</string>
+    <string name="tooltip_review_privacy">Tap to review your privacy settings</string>
+
+    <!-- ================== Graph titles ==================== -->
+    <string name="graphs_no_data">Add your first receipts to see graphs.</string>
+    <string name="graphs_expenditure_by_dates_title">Daily expenses</string>
+    <string name="graphs_expenditure_by_categories_title">Expenditure by categories</string>
+    <string name="graphs_expenditure_by_reimbursable_title">Reimbursable vs Non-reimbursable</string>
+    <string name="graphs_expenditure_by_payment_methods_title">Expenditure by payment methods</string>
+    <string name="graphs_label_reimbursable">Reimbursable</string>
+    <string name="graphs_label_non_reimbursable">Non-reimbursable</string>
+    <string name="graphs_label_others">Others</string>
+
+</resources>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -206,117 +206,117 @@
     <string name="attachment_error">Unable to attach this file.</string>
 
     <!-- ================== Trip Adapter ===================== -->
-    <string name="trip_adapter_list_item_to">\u0020to\u0020</string>
-    <string name="trip_no_data">You don\'t seem to have any reports defined at the moment. Try clicking the "+" (plus) button to get started.\n\nSmart Receipts lets you create Expense reports, track receipts within each, and quickly generate PDF &amp; CSV reports for your receipt totals. It\'s quick and easy! Also, be sure to check out the menu to customize the categories, reports, and other settings to best suit for your needs.</string>
-	<string name="trip_no_data">אין לך דו״ֿ\חות מוגדרים כרגע - נסה ללחוץ על כפתור ה״+״ ע״מ להוסיף ד/״.</string>
+    <string name="trip_adapter_list_item_to">\u0020אל\u0020</string>
+	<string name="trip_no_data">אין לך דוחות מוגדרים כרגע. נסה ללחוץ על + על מנת להתחיל. \n\n האפליקציה מאפשר לך ליצור דוחות הוצאה, לעקוב אחרי קבלות בכל אחד מהדוחות, ולייצר דוחות PDF וCSV להוצאות שלך. זה קל ופשוט! בנוסף, ניתן לבצע התאמה אישית לקטגוריות, דוחות ושאר הגדרות בתפריט ההגדרות על מנת להתאים את התוכנה לצרכיך.</string>
 	
 
     <!-- ================= Receipt Adapter =================== -->
-    <string name="receipt_no_data">You don\'t seem to have any receipts yet. Try tapping the "+" (plus) button to get started&#8230;</string>
+    <string name="receipt_no_data">נראה שאין לך קבלות. לחץ על + על מנת להתחיל.&#8230;</string>
+	
 
     <!-- ================= Distance Adapter ================== -->
-    <string name="distance_no_data">You don\'t seem to have any distance tracked yet. Try clicking the "+" (plus) button to get started.</string>
-    <string name="distance_insert_failed">Error: Failed to create this distance item. Please make sure your phone is not mounted to your computer.</string>
-    <string name="distance_update_failed">Error: Failed to update this distance item. Please make sure your phone is not mounted to your computer.</string>
-    <string name="distance_delete_failed">Error: Failed to delete this distance item. Please make sure your phone is not mounted to your computer.</string>
+	<string name="distance_no_data">לא תיעדת מרחק עדיין. נסה ללחוץ על + על מנת להתחיל.</string>
+    <string name="distance_insert_failed">תקלה: יצירת פריט המרחק נכשלה. אנא וודא שהמכשיר שלך לא מחובר למחשב.</string>
+    <string name="distance_update_failed">תקלה: עדכון פריט המרחק נכשל. אנא וודא שהמכשיר שלך לא מחובר למחשב.</string>
+    <string name="distance_delete_failed">תקלה: מחיקת פירט המרחק נכשלה. אנא וודא שהמכשיר שלך לא מחובר למחשב.</string>
 
     <!-- ================= Trip Actions =================== -->
 
     <!-- ================= Receipt Actions =================== -->
-    <string name="receipt_action_camera">Picture</string>
-    <string name="receipt_action_text">Text-Only</string>
-    <string name="receipt_action_import">Import</string>
+    <string name="receipt_action_camera">צלם</string>
+    <string name="receipt_action_text">טקסט</string>
+    <string name="receipt_action_import">ייבא</string>
 
     <!-- ==================== Cards ========================= -->
 
     <!-- ================ DIALOG (GENERAL) =================== -->
-    <string name="DIALOG_CANCEL">Cancel</string>
+    <string name="DIALOG_CANCEL">ביטול</string>
 
     <!-- ================= DIALOG_WELCOME ==================== -->
 
     <!-- ================== DIALOG_EMAIL ===================== -->
-    <string name="DIALOG_EMAIL_CHECKBOX_PDF_FULL">Full PDF Report</string>
-    <string name="DIALOG_EMAIL_CHECKBOX_PDF_IMAGES">PDF Report - No Table</string>
-    <string name="DIALOG_EMAIL_CHECKBOX_CSV">CSV File</string>
-    <string name="DIALOG_EMAIL_CHECKBOX_ZIP_WITH_METADATA">ZIP - Receipt Files with Metadata</string>
-    <string name="DIALOG_EMAIL_CHECKBOX_ZIP">ZIP - Receipts Files</string>
-    <string name="DIALOG_EMAIL_TOAST_NO_SELECTION">Please Check At Least One Report</string>
-    <string name="DIALOG_EMAIL_TOAST_NO_RECEIPTS">There are No Receipts in this Report</string>
-    <string name="generate_report_tooltip">Tap to configure the report layouts</string>
+    <string name="DIALOG_EMAIL_CHECKBOX_PDF_FULL">דוח PDF מלא</string>
+    <string name="DIALOG_EMAIL_CHECKBOX_PDF_IMAGES">דוח PDF ללא טבלה</string>
+    <string name="DIALOG_EMAIL_CHECKBOX_CSV">קובץ CSV</string>
+    <string name="DIALOG_EMAIL_CHECKBOX_ZIP_WITH_METADATA">קובץ ZIP - קבצי קבלות עם מטא-דאטה</string>
+    <string name="DIALOG_EMAIL_CHECKBOX_ZIP">קובץ Zip - קבצי קבלות</string>
+    <string name="DIALOG_EMAIL_TOAST_NO_SELECTION">אנא סמן לפחות קבלה אחת</string>
+    <string name="DIALOG_EMAIL_TOAST_NO_RECEIPTS">אין קבלות בדוח הזה</string>
+    <string name="generate_report_tooltip">לחץ להגדרת תצוגת הדוח</string>
 
 
     <!-- ================= DIALOG_SETTINGS =================== -->
 
 
     <!-- ================= DIALOG_TRIPMENU =================== -->
-    <string name="DIALOG_TRIPMENU_HINT_NAME">Name</string>
-    <string name="DIALOG_TRIPMENU_HINT_START">Start Date</string>
-    <string name="DIALOG_TRIPMENU_HINT_END">End Date</string>
-    <string name="DIALOG_TRIPMENU_TITLE_NEW">New Expense Report</string>
-    <string name="DIALOG_TRIPMENU_TITLE_EDIT">Edit Report</string>
-    <string name="DIALOG_TRIPMENU_TOAST_MISSING_FIELD">Please Fill Out All Fields</string>
+    <string name="DIALOG_TRIPMENU_HINT_NAME">שם</string>
+    <string name="DIALOG_TRIPMENU_HINT_START">תאריך התחלה</string>
+    <string name="DIALOG_TRIPMENU_HINT_END">תאריך סיום</string>
+    <string name="DIALOG_TRIPMENU_TITLE_NEW">דוח הוצאות חדש</string>
+    <string name="DIALOG_TRIPMENU_TITLE_EDIT">עריכת דוח</string>
+    <string name="DIALOG_TRIPMENU_TOAST_MISSING_FIELD">אנא מלא את כל השדות</string>
 
     <!-- =============== DIALOG_TRIP_DELETE ================== -->
-    <string name="DIALOG_TRIP_DELETE_POSITIVE_BUTTON">Delete</string>
+    <string name="DIALOG_TRIP_DELETE_POSITIVE_BUTTON">מחק</string>
 
     <!-- ================= DIALOG_RECEIPTMENU =================== -->
-    <string name="DIALOG_RECEIPTMENU_HINT_NAME">Name</string>
-    <string name="DIALOG_RECEIPTMENU_HINT_PRICE">Price (e.g. 150.00)</string>
-    <string name="DIALOG_RECEIPTMENU_HINT_PRICE_SHORT">Price</string>
-    <string name="DIALOG_RECEIPTMENU_HINT_TAX">Tax</string>
-    <string name="DIALOG_RECEIPTMENU_HINT_CURRENCY">Currency</string>
-    <string name="DIALOG_RECEIPTMENU_HINT_EXCHANGE_RATE">Exchange Rate</string>
-    <string name="DIALOG_RECEIPTMENU_HINT_EXCHANGE_RATE_FAILED">Exchange Rate Failed. Retry?</string>
-    <string name="receipt_input_exchanged_result_hint">Base Currency Price</string>
-    <string name="DIALOG_RECEIPTMENU_HINT_DATE">Date</string>
-    <string name="DIALOG_RECEIPTMENU_HINT_CATEGORY">Category</string>
-    <string name="DIALOG_RECEIPTMENU_HINT_COMMENT">Comment</string>
-    <string name="DIALOG_RECEIPTMENU_HINT_COST_CENTER">Cost Center</string>
-    <string name="DIALOG_RECEIPTMENU_HINT_EXPENSABLE">Reimbursable?</string>
-    <string name="DIALOG_RECEIPTMENU_HINT_FULLPAGE"> Full-Page Image?</string>
-    <string name="DIALOG_RECEIPTMENU_TITLE_NEW">New Receipt</string>
-    <string name="DIALOG_RECEIPTMENU_TITLE_NEW_ID">New Receipt - %s</string>
-    <string name="DIALOG_RECEIPTMENU_TITLE_EDIT">Edit Receipt</string>
-    <string name="DIALOG_RECEIPTMENU_TITLE_EDIT_ID">Edit Receipt - %s</string>
-    <string name="DIALOG_RECEIPTMENU_TOAST_BAD_DATE">Warning: This Receipt\'s Date falls outside the specified range for this Report</string>
-    <string name="manage_categories">Manage Categories</string>
-    <string name="manage_payment_methods">Manage Payment Methods</string>
+    <string name="DIALOG_RECEIPTMENU_HINT_NAME">שם</string>
+    <string name="DIALOG_RECEIPTMENU_HINT_PRICE">מחיר (למשל 150.00)</string>
+    <string name="DIALOG_RECEIPTMENU_HINT_PRICE_SHORT">מחיר</string>
+    <string name="DIALOG_RECEIPTMENU_HINT_TAX">מס</string>
+    <string name="DIALOG_RECEIPTMENU_HINT_CURRENCY">מטבע</string>
+    <string name="DIALOG_RECEIPTMENU_HINT_EXCHANGE_RATE">שער חליפין</string>
+    <string name="DIALOG_RECEIPTMENU_HINT_EXCHANGE_RATE_FAILED">שער חליפין נכשל. נסה שוב?</string>
+    <string name="receipt_input_exchanged_result_hint">מחיר מטבע בסיסי</string>
+    <string name="DIALOG_RECEIPTMENU_HINT_DATE">תאריך</string>
+    <string name="DIALOG_RECEIPTMENU_HINT_CATEGORY">קטגוריה</string>
+    <string name="DIALOG_RECEIPTMENU_HINT_COMMENT">הערה</string>
+    <string name="DIALOG_RECEIPTMENU_HINT_COST_CENTER">מרכז עלות</string>
+    <string name="DIALOG_RECEIPTMENU_HINT_EXPENSABLE">בר החזר?</string>
+    <string name="DIALOG_RECEIPTMENU_HINT_FULLPAGE">תמונה בדף מלא?</string>
+    <string name="DIALOG_RECEIPTMENU_TITLE_NEW">קבלה חדשה</string>
+    <string name="DIALOG_RECEIPTMENU_TITLE_NEW_ID">קבלה חדשה - %s</string>
+    <string name="DIALOG_RECEIPTMENU_TITLE_EDIT">עריכת קבלה</string>
+    <string name="DIALOG_RECEIPTMENU_TITLE_EDIT_ID">עריכת קבלה -  %s</string>
+    <string name="DIALOG_RECEIPTMENU_TOAST_BAD_DATE">אזהרה: תאריך הקבלה הזו נופל מחוץ לטווח התאריכים של דוח ההוצאות הנוכחי</string>
+    <string name="manage_categories">נהל קטגוריות</string>
+    <string name="manage_payment_methods">נהל אמצעי תשלום</string>
 
     <!-- ================= DIALOG_RECEIPT_ATTACHMENT =================== -->
-    <string name="receipt_attach_photo">Take a photo</string>
-    <string name="receipt_attach_image">Pick a photo</string>
-    <string name="receipt_attach_file">Attach file</string>
+    <string name="receipt_attach_photo">צלם תמונה</string>
+    <string name="receipt_attach_image">בחר תמונה</string>
+    <string name="receipt_attach_file">צרף קובץ</string>
 
 
     <!-- ==================== dialog export / import ====================== -->
-    <string name="dialog_export_title">Export your receipts?</string>
-    <string name="dialog_export_text">You can reimport your data by clicking on the SmartReceipts.SMR file, which is generated by clicking below.</string>
-    <string name="dialog_export_positive">Export</string>
-    <string name="dialog_import_positive">Import</string>
-    <string name="dialog_import_text">Overwrite All Existing Data</string>
-    <string name="dialog_export_working">Exporting your receipts&#8230;</string>
+    <string name="dialog_export_title">ייצא את הקבלות שלך?</string>
+    <string name="dialog_export_text">אתה יכול לייבא את המידע שלך מחדש על ידי לחיצה על קובץ SmartReceipts.SMR file , המיוצר על ידי לחיצה על הכפתור מטה.</string>
+    <string name="dialog_export_positive">ייצוא</string>
+    <string name="dialog_import_positive">ייבוא</string>
+    <string name="dialog_import_text">דריסת כל המידע הקיים</string>
+    <string name="dialog_export_working">ייצוא הקבלות שלך&#8230;</string>
 
     <!-- ==================== DIALOG_ABOUT ====================== -->
 
     <!-- ====================== Distance Report ======================== -->
-    <string name="distance_location_field">Location</string>
-    <string name="distance_price_field">Price</string>
-    <string name="distance_distance_field">Distance</string>
-    <string name="distance_rate_field">Rate</string>
-    <string name="dialog_currency_field">Currency</string>
-    <string name="distance_date_field">Date</string>
-    <string name="distance_comment_field">Comment</string>
+    <string name="distance_location_field">מרחק</string>
+    <string name="distance_price_field">מחיר</string>
+    <string name="distance_distance_field">מרחק</string>
+    <string name="distance_rate_field">תעריף</string>
+    <string name="dialog_currency_field">מטבע</string>
+    <string name="distance_date_field">תאריך</string>
+    <string name="distance_comment_field">הערה</string>
 
     <!-- ====================== Categories Summation Report ======================== -->
-    <string name="category_name_field">Category</string>
-    <string name="category_code_field">Category Code</string>
-    <string name="category_price_field">Price</string>
-    <string name="category_tax_field">Tax</string>
-    <string name="category_currency_field">Currency</string>
+    <string name="category_name_field">קטגוקיה</string>
+    <string name="category_code_field">קוד קטגוריה</string>
+    <string name="category_price_field">מחיר</string>
+    <string name="category_tax_field">מס</string>
+    <string name="category_currency_field">מטבע</string>
 
     <!-- ===================== backup menu ======================== -->
-    <string name="backups">Backups</string>
-    <string name="manual_backup_title">Manual Backups:</string>
+    <string name="backups">גיבויים</string>
+    <string name="manual_backup_title">גיבויים ידניים:</string>
     <string name="manual_backup_description">Back up your data to keep your receipts safe! You can restore your data by importing the SmartReceipts.SMR backup file, which is generated via the "Backup" button below.</string>
     <string name="manual_backup_export">Backup</string>
     <string name="manual_backup_import">Import</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -40,8 +40,8 @@
     <string name="no">לא</string>
     <string name="pdf">PDF</string>
     <string name="report">דו״ח</string>
-    <string name="report_attached">דו״ח 1 מצ״ב</string>
-    <string name="reports_attached">דו״חות מצורפים %s</string>
+    <string name="report_attached">דו״\ח 1 מצ״ב</string>
+    <string name="reports_attached">דו״\חות מצורפים %s</string>
     <string name="save">שמור</string>
     <string name="send_email">&#8230;שלח קובץ</string>
     <string name="submit">שלח</string>
@@ -78,12 +78,12 @@
     <string name="report_header_receipts_total_reimbursable">%s :סה״כ (זכאי להחזרים)</string>
     <string name="report_header_grand_total">%s :סה״כ</string>
     <string name="report_header_cost_center">%s :מרכז מחיר</string>
-    <string name="report_header_comment">%s :הערה לדו״ח</string>
-    <string name="report_pdf_generation_error">שגיאה בייצור הדו״ח</string>
+    <string name="report_header_comment">%s :הערה לדו״\ח</string>
+    <string name="report_pdf_generation_error">שגיאה בייצור הדו״\ח</string>
     <string name="report_pdf_error_too_many_columns_title">יותר מדי עמודות</string>
-	<string name="report_pdf_error_too_many_columns_message">.אין מספיק מקום ע״מ להכיל את כל העמודות בדו״ח. אנא נסה להגביל את מספר העמודות בהגדרות</string>
+	<string name="report_pdf_error_too_many_columns_message">.אין מספיק מקום ע״מ להכיל את כל העמודות בדו״\ח. אנא נסה להגביל את מספר העמודות בהגדרות</string>
 
-	<string name="report_pdf_error_too_many_columns_message_landscape">.אין מספיק מקום ע״מ להכיל את כל העמודות בדו״ח. אנא נסה להגביל את מספר העמודות בהגדרות או עבור למצב מסך מאוזן</string>
+	<string name="report_pdf_error_too_many_columns_message_landscape">.אין מספיק מקום ע״מ להכיל את כל העמודות בדו״\ח. אנא נסה להגביל את מספר העמודות בהגדרות או עבור למצב מסך מאוזן</string>
 	
     <string name="report_pdf_error_go_to_settings">עבור להגדרות</string>
 
@@ -170,39 +170,39 @@
 
     <!-- ============== Progress Messages ================= -->
     <string name="progress_import">מעלה את הקבצים שלך&#8230;</string>
-    <string name="progress_building_reports">...בונה דו״חות</string>
+    <string name="progress_building_reports">...בונה דו״\חות</string>
 
     <!-- ============== Start Error Messages ================= -->
-    <string name="SD_ERROR">Error: Please make sure that your SD Card is available and not mounted to your computer.</string>
-    <string name="SD_WARNING">Warning: Your SD Card is not available or is mounted to your computer. Some images may be inaccessible. Switching to internal storage&#8230;</string>
-    <string name="database_error">Error: Failed to save your receipt</string>
-    <string name="database_get_error">Error: Failed to fetch your data. Try re-launching the app.</string>
-    <string name="IMG_OPEN_ERROR">Error: The image is currently inaccessible or corrupted. Your SD Card may be unavailable or mounted to your computer. If not, click the menu button to retake the photo.</string>
-    <string name="IMG_SAVE_ERROR">Error: The Image Failed to Save Properly</string>
-    <string name="FILE_SAVE_ERROR">Error: The File Failed to Save Properly</string>
-    <string name="ILLEGAL_CHAR_ERROR">Error: The name contains an illegal character</string>
-    <string name="SPACE_ERROR">Error: The name cannot begin with a space</string>
-    <string name="CALENDAR_TAB_ERROR">Error: Please Touch the Date TextBox to set the Date</string>
-    <string name="DURATION_ERROR">Error: The Start Date Must Occur Prior To The End Date</string>
-    <string name="EXPORT_ERROR">Error: Failed to properly export your data.</string>
-    <string name="IMPORT_ERROR">Error: Failed to recognize the file as importable</string>
-    <string name="MOVE_ERROR">Error: Failed to move the receipt</string>
-    <string name="COPY_ERROR">Error: Failed to copy the receipt</string>
-    <string name="toast_warning_reset_exchange_rate">Warning: Changing the currency will reset ALL exchange rates</string>
-    <string name="toast_error_trip_exists">Error: An expense report with that name already exists</string>
-    <string name="toast_error_category_exists">Error: An category with that name already exists</string>
+	    <string name="SD_ERROR">.תקלה: אנא וודא שכרטיס הזכרון שלך זמין ולא מחובר למחשב שלך</string>
+	    <string name="SD_WARNING">אזהרה: כרטיס הזכרון שלך לא זמין או מחובר למחשב שלך. חלק מהתמונות עלולות להיות בלתי נגישות. מחליף לזכרון פנימי&#8230;</string>
+    <string name="database_error">תקלה: שמירת קבלה נכשלה</string>
+    <string name="database_get_error">.תקלה: בלתי אפשרי לגשת למידע שלך. אנא הפעל מחדש את האפליקציה</string>
+	    <string name="IMG_OPEN_ERROR">.תקלה: התמונה כרגע בלתי נגישה או פגומה. כרטיס הזכרון שלך עלול להיות בלתי זמין או מחובר למחשב שלך. אם הוא לא, אנא לחץ על כפתור התפריט על מנת לצלם את התמונה מחדש.</string>
+	    <string name="IMG_SAVE_ERROR">תקלה: התמונה לא נשמרה כראוי</string>
+    <string name="FILE_SAVE_ERROR">תקלה: הקובץ לא נשמר כראוי</string>
+    <string name="ILLEGAL_CHAR_ERROR">תקלה: שם הקובץ מכיל תו בלתי חורי</string>
+    <string name="SPACE_ERROR">תקלה: השם לא יכול להתחיל עם רווח</string>
+    <string name="CALENDAR_TAB_ERROR">תקלה: אנא לחץ על תיבת הטקסט של התאריך על מנת לקבוע את התאריך</string>
+    <string name="DURATION_ERROR">תקלה: תאריך ההתחלה חייב להיות לפני תאריך הסיום</string>
+    <string name="EXPORT_ERROR">.תקלה: לא ניתן לייצא את המידע שלך כראוי</string>
+    <string name="IMPORT_ERROR">.תקלה: לא ניתן לזהות את הקובץ כבר-ייבוא</string>
+    <string name="MOVE_ERROR">תקלה: לא ניתן להזיז את הקבלה</string>
+    <string name="COPY_ERROR">תקלה: לא ניתן להעתיק את הקבלה</string>
+    <string name="toast_warning_reset_exchange_rate">אזהרה: שינוי המטבע יאתחל את כל המטבעות ושערי החליפין</string>
+    <string name="toast_error_trip_exists">תקלה: דו״\ח בשם הזה קיים כבר</string>
+    <string name="toast_error_category_exists">תקלה: קטגוריה בשם הזה קיימת כבר</string>
 
     <!-- ============== Toast Messages ================= -->
-    <string name="toast_receipt_copy">Successfully copied the receipt</string>
-    <string name="toast_receipt_move">Successfully moved the receipt</string>
-    <string name="toast_receipt_image_added">Successfully added a new image to %s</string>
-    <string name="toast_receipt_image_replaced">Successfully replaced a new image for %s</string>
-    <string name="toast_receipt_pdf_added">Successfully added a new PDF to %s</string>
-    <string name="toast_receipt_pdf_replaced">Successfully replaced a new PDF for %s</string>
-    <string name="toast_no_storage_permissions">Cannot import file without storage permissions</string>
-    <string name="toast_import_complete">Successfully imported all files. Please re-launch the app.</string>
-    <string name="toast_reorder_hint"><![CDATA[Long press item to initiate dragging]]></string>
-    <string name="toast_csv_report_distances">To create CSV report please check option %s</string>
+    <string name="toast_receipt_copy">הקבלה הועתקה בהצלחה</string>
+    <string name="toast_receipt_move">הקבלה הועברה בהצלחה</string>
+    <string name="toast_receipt_image_added">%s :נוספה תמונה חדשה בהצלחה ל</string>
+    <string name="toast_receipt_image_replaced">%s :הוחלפה בהצלחה התמונה של</string>
+    <string name="toast_receipt_pdf_added">%s :נוסף בהצלחה קובץ פידיאף ל</string>
+    <string name="toast_receipt_pdf_replaced">%s :הוחלף בהצלחה קובץ פידיאף ל</string>
+    <string name="toast_no_storage_permissions">לא ניתן לייבא קובץ בלי הרשאות לאחסון של הטלפון</string>
+    <string name="toast_import_complete">.יובאו כל הקבצים בהצלחה. אנא אתחל את האפליקציה.</string>
+    <string name="toast_reorder_hint"><![CDATA[לחץ לחיצה ארוכה על הפריט על מנת להתחיל גרירה]]></string>
+    <string name="toast_csv_report_distances">%s :על מנת ליצור דו״\ח אקסל אנא לחץ על</string>
     <string name="attachment_error">Unable to attach this file.</string>
 
     <!-- ================== Trip Adapter ===================== -->

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -121,56 +121,56 @@
     <string name="category_dinner_code">DINN</string>
     <string name="category_entertainment">בידור</string>
     <string name="category_entertainment_code">ENT</string>
-    <string name="category_gasoline">Gasoline</string>
+    <string name="category_gasoline">דלק</string>
     <string name="category_gasoline_code">GAS</string>
-    <string name="category_gift">Gift</string>
+    <string name="category_gift">מתנה</string>
     <string name="category_gift_code">GIFT</string>
-    <string name="category_hotel">Hotel</string>
+    <string name="category_hotel">מלון</string>
     <string name="category_hotel_code">HTL</string>
-    <string name="category_laundry">Laundry</string>
+    <string name="category_laundry">כביסה</string>
     <string name="category_laundry_code">LAUN</string>
-    <string name="category_lunch">Lunch</string>
+    <string name="category_lunch">ארוחת צהריים</string>
     <string name="category_lunch_code">LNCH</string>
-    <string name="category_other">Other</string>
+    <string name="category_other">שונות</string>
     <string name="category_other_code">MISC</string>
-    <string name="category_parking_tolls">Parking/Tolls</string>
+    <string name="category_parking_tolls">חנייה/עמלות</string>
     <string name="category_parking_tolls_code">PARK</string>
-    <string name="category_postage_shipping">Postage/Shipping</string>
+    <string name="category_postage_shipping">דואר/משלוחים</string>
     <string name="category_postage_shipping_code">POST</string>
-    <string name="category_car_rental">Car Rental</string>
+    <string name="category_car_rental">שכירת רכב</string>
     <string name="category_car_rental_code">RCAR</string>
-    <string name="category_taxi_bus">Taxi/Bus</string>
+    <string name="category_taxi_bus">מונית/אוטובוס</string>
     <string name="category_taxi_bus_code">TAXI</string>
-    <string name="category_telephone_fax">Telephone/Fax</string>
+    <string name="category_telephone_fax">טלפון/פקס</string>
     <string name="category_telephone_fax_code">TELE</string>
-    <string name="category_tip">Tip</string>
+    <string name="category_tip">טיפ</string>
     <string name="category_tip_code">TIP</string>
-    <string name="category_train">Train</string>
+    <string name="category_train">רכבת</string>
     <string name="category_train_code">TRN</string>
-    <string name="category_books_periodicals">Books/Periodicals</string>
+    <string name="category_books_periodicals">ספרים/מגזינים</string>
     <string name="category_books_periodicals_code">ZBKP</string>
-    <string name="category_cell_phone">Cell Phone</string>
+    <string name="category_cell_phone">סלולרי</string>
     <string name="category_cell_phone_code">ZCEL</string>
-    <string name="category_dues_subscriptions">Dues/Subscriptions</string>
+    <string name="category_dues_subscriptions">מנויים/הוראות קבע</string>
     <string name="category_dues_subscriptions_code">ZDUE</string>
-    <string name="category_meals_justified">Meals (Justified)</string>
+    <string name="category_meals_justified">ארוחות (בר-החזר)</string>
     <string name="category_meals_justified_code">ZMEO</string>
-    <string name="category_stationery_stations">Stations</string>
+    <string name="category_stationery_stations">תחנות</string>
     <string name="category_stationery_stations_code">ZSTS</string>
-    <string name="category_training_fees">Training Fees</string>
+    <string name="category_training_fees">עמלות אימון</string>
     <string name="category_training_fees_code">ZTRN</string>
 
     <!-- ================ Img Menu Options =================== -->
-    <string name="menu_receiptimage_retake">Retake Photo</string>
-    <string name="menu_receiptimage_rotate_ccw">Rotate CCW</string>
-    <string name="menu_receiptimage_rotate_cw">Rotate CW</string>
+    <string name="menu_receiptimage_retake">צלם מחדש</string>
+    <string name="menu_receiptimage_rotate_ccw">סובב נגד כיוון השעון</string>
+    <string name="menu_receiptimage_rotate_cw">סובב עם כיוון השעון</string>
 
     <!-- ===================== Email ====================== -->
-    <string name="email_body_subject_5mb_warning">The following attachment is over 5MB in size and may not properly attach: %s</string>
+    <string name="email_body_subject_5mb_warning">%s :הקובץ המצ״ב גדול מ-5 מגהבייט, ולכן ייתכן שלא יוצמד כראוי</string>
 
     <!-- ============== Progress Messages ================= -->
-    <string name="progress_import">Importing your files&#8230;</string>
-    <string name="progress_building_reports">Building Reports…</string>
+    <string name="progress_import">מעלה את הקבצים שלך&#8230;</string>
+    <string name="progress_building_reports">...בונה דו״חות</string>
 
     <!-- ============== Start Error Messages ================= -->
     <string name="SD_ERROR">Error: Please make sure that your SD Card is available and not mounted to your computer.</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -515,17 +515,17 @@
     <string name="tooltip_generate_info_message">השתמש בטאב הייצור על מנת ליצור את הדוחות שלך</string>
     <string name="tooltip_backup_info_message">%d ימים מאז הגיבוי האחרון שלך</string>
     <string name="tooltip_no_backups_info_message">תזכורת: גבה את המידע שלך באופן קבוע</string>
-    <string name="tooltip_import_info_message">Please, choose receipt for your attachment</string>
-    <string name="tooltip_review_privacy">Tap to review your privacy settings</string>
+    <string name="tooltip_import_info_message">אנא בחר קבלה עבור הקובץ המצורף שלך</string>
+    <string name="tooltip_review_privacy">לחץ לעיון של הגדרות הפרטיות שלך</string>
 
     <!-- ================== Graph titles ==================== -->
-    <string name="graphs_no_data">Add your first receipts to see graphs.</string>
-    <string name="graphs_expenditure_by_dates_title">Daily expenses</string>
-    <string name="graphs_expenditure_by_categories_title">Expenditure by categories</string>
-    <string name="graphs_expenditure_by_reimbursable_title">Reimbursable vs Non-reimbursable</string>
-    <string name="graphs_expenditure_by_payment_methods_title">Expenditure by payment methods</string>
-    <string name="graphs_label_reimbursable">Reimbursable</string>
-    <string name="graphs_label_non_reimbursable">Non-reimbursable</string>
-    <string name="graphs_label_others">Others</string>
+    <string name="graphs_no_data">הוסף קבלות ראשונות על מנת לצפות בגרפים</string>
+    <string name="graphs_expenditure_by_dates_title">הוצאות יומיות</string>
+    <string name="graphs_expenditure_by_categories_title">הוצאה לפי קטגוריה</string>
+    <string name="graphs_expenditure_by_reimbursable_title">בר-החזר לעומת לא בר-החזר</string>
+    <string name="graphs_expenditure_by_payment_methods_title">הוצאה לפי אמצעי תשלום</string>
+    <string name="graphs_label_reimbursable">בר-החזר</string>
+    <string name="graphs_label_non_reimbursable">לא בר-החזר</string>
+    <string name="graphs_label_others">אחרים</string>
 
 </resources>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -407,51 +407,51 @@
     </string-array>
 
     <!-- ============== CSV/PDF Columns ================== -->
-    <string name="column_item_blank">Blank Column</string>
-    <string name="column_item_category_code">Category Code</string>
-    <string name="column_item_category_name">Category Name</string>
-    <string name="column_item_user_id">User ID</string>
-    <string name="column_item_report_name">Report Name</string>
-    <string name="column_item_report_start_date">Report Start Date</string>
-    <string name="column_item_report_end_date">Report End Date</string>
-    <string name="column_item_report_comment">Report Comment</string>
-    <string name="column_item_report_cost_center">Report Cost Center</string>
-    <string name="column_item_image_file_name">Image Name</string>
-    <string name="column_item_image_path">Image Path</string>
+    <string name="column_item_blank">עמודה ריקה</string>
+    <string name="column_item_category_code">קוד קטגוריה</string>
+    <string name="column_item_category_name">שם קטגוריה</string>
+    <string name="column_item_user_id">מזהה משתמש</string>
+    <string name="column_item_report_name">שם דוח</string>
+    <string name="column_item_report_start_date">תאריך תחילת דוח</string>
+    <string name="column_item_report_end_date">תאריך סוף דוח</string>
+    <string name="column_item_report_comment">הערת דוח</string>
+    <string name="column_item_report_cost_center">מרכז עלות דוח</string>
+    <string name="column_item_image_file_name">שם תמונה</string>
+    <string name="column_item_image_path">נתיב לתמונה</string>
     <!-- **Please note that for flex purposes, some of these use the legacy names above** -->
-    <string name="column_item_receipt_price_minus_tax">Price Minus Tax</string>
-    <string name="column_item_converted_price_exchange_rate">Price (Exchanged)</string>
-    <string name="column_item_converted_tax_exchange_rate">Tax (Exchanged)</string>
-    <string name="column_item_converted_price_plus_tax_exchange_rate">Price Plus Tax (Exchanged)</string>
-    <string name="column_item_converted_price_minus_tax_exchange_rate">Price Minus Tax (Exchanged)</string>
-    <string name="column_item_exchange_rate">Exchange Rate</string>
-    <string name="column_item_pictured">Pictured</string>
-    <string name="column_item_reimbursable">Reimbursable</string>
+    <string name="column_item_receipt_price_minus_tax">מחיר פחות מס</string>
+    <string name="column_item_converted_price_exchange_rate">מחיר לאחר המרה</string>
+    <string name="column_item_converted_tax_exchange_rate">מס לאחר המרה</string>
+    <string name="column_item_converted_price_plus_tax_exchange_rate">מחיר פלוס מס לאחר המרה</string>
+    <string name="column_item_converted_price_minus_tax_exchange_rate">מחיר פחות לאחר המרה</string>
+    <string name="column_item_exchange_rate">שער חליפין</string>
+    <string name="column_item_pictured">בתמונה</string>
+    <string name="column_item_reimbursable">בר-החזר</string>
     <string name="column_item_deprecated_expensable" translatable="false">Expensable</string>
-    <string name="column_item_index">Receipt Index</string>
-    <string name="column_item_id">Receipt ID</string>
-    <string name="column_item_payment_method">Payment Method</string>
+    <string name="column_item_index">אינדקס קבלה</string>
+    <string name="column_item_id">מזהה קבלה</string>
+    <string name="column_item_payment_method">אמצעי תשלום</string>
 
-    <string name="receipt_dialog_action_edit">Edit Receipt</string>
-    <string name="receipt_dialog_action_view">View Receipt %s</string>
-    <string name="receipt_dialog_action_delete">Delete Receipt</string>
-    <string name="receipt_dialog_action_move_copy">Move/Copy</string>
-    <string name="receipt_dialog_action_remove_attachment">Remove Attachment</string>
+    <string name="receipt_dialog_action_edit">ערוך קבלה</string>
+    <string name="receipt_dialog_action_view">הראה קבלה %s</string>
+    <string name="receipt_dialog_action_delete">מחק קבלה</string>
+    <string name="receipt_dialog_action_move_copy">העבר/העתק</string>
+    <string name="receipt_dialog_action_remove_attachment">מחק קובץ מצורף</string>
 
-    <string name="dialog_attachment_text">Tap on an existing receipt to add this %s to it</string>
-    <string name="receipt_dialog_remove_attachment">Do you want to remove attachment?</string>
+    <string name="dialog_attachment_text">לחץ על קבלה קיימת כדי להוסיף אליה את %s </string>
+    <string name="receipt_dialog_remove_attachment">האם אתה רוצה למחוק את הקובץ המצורף?</string>
 
     <!-- ================== Preference Dialog ==================== -->
-    <string name="dialog_custom_csv_spinner">Column Type</string>
-    <string name="dialog_category_add">Add Category</string>
-    <string name="dialog_category_edit">Edit Category</string>
+    <string name="dialog_custom_csv_spinner">סוג עמודה</string>
+    <string name="dialog_category_add">הוסף קטגוריה</string>
+    <string name="dialog_category_edit">ערוך קטגוריה</string>
 
     <!-- ================ Error Feedback ==================== -->
-    <string name="error_no_pdf_activity_viewer">Failed to find a PDF Viewer Application</string>
-    <string name="error_no_send_intent_dialog_title">No Send App Found</string>
-    <string name="error_no_send_intent_dialog_message">We could not find an email application (or equivalent) on your phone. You can find your files in the following directory: %s</string>
-    <string name="error_no_file_intent_dialog_title">Error: Unable to find an "import" installed app on your device</string>
-    <string name="error_no_wifi">Error: Not connected to WiFi</string>
+    <string name="error_no_pdf_activity_viewer">לא קיימת אפליקציה לצפייה בקבצי PDF</string>
+    <string name="error_no_send_intent_dialog_title">לא קיימת אפליקציה לשליחה</string>
+    <string name="error_no_send_intent_dialog_message">לא יכולנו למצוא אפליקציה של דואר אלקטרוני (או אפליקציה דומה) על מכשיר הטלפון שלך. תוכל למצוא את הקבצים בתיקייה הבאה: %s</string>
+	<string name="error_no_file_intent_dialog_title">שגיאה: לא נמצאה אפליקצית גיבוי על הטלפון שלך</string>
+    <string name="error_no_wifi">שגיאה: לא מחובר לווייפיי</string>
 
     <!-- ================== ActionBar ===================== -->
 
@@ -460,54 +460,56 @@
     <!-- ================== Legacy Camera ==================== -->
 
     <!-- ================== SQL Corrpution ==================== -->
-    <string name="dialog_sql_corrupt_title">Oh No!</string>
+    <string name="dialog_sql_corrupt_title">הו לא!</string>
     <string name="dialog_sql_corrupt_message">Your database was corrupted. This often occurs if you have a task killer app, but it can be caused by a few different things. Don\'t worry, we should be able to restore most of your data.</string>
-    <string name="dialog_sql_corrupt_positive">Email the Developer for Help</string>
-    <string name="dialog_sql_corrupt_intent_subject">Smart Receipts - Corrupted Database</string>
+	    <string name="dialog_sql_corrupt_message">מסד הנתונים שלך פגום. מצב זה קורה לרוב אם יש לך אפליקצית ״הריגת״ מטלות ברקע, אבל הוא יכול להיגרם מכל מיני סיבות. אל תדאג, נוכל לשחזר את המידע שלך.</string>
+    <string name="dialog_sql_corrupt_positive">שלח דואר אלקטרוני למפתח על מנת לבקש סיוע</string>
+    <string name="dialog_sql_corrupt_intent_subject">Smart Receipts - מסדי נתונים פגומים</string>
     <string name="dialog_sql_corrupt_intent_text">Help - my database was corrupted. How can you help me restore things?</string>
-    <string name="dialog_sql_corrupt_chooser">Send Email&#8230;</string>
+    <string name="dialog_sql_corrupt_intent_text">עזרה - מסד הנתונים שלי פגום. כיצד תוכל לעזור לי לשחזר את המידע שלי?</string>
+    <string name="dialog_sql_corrupt_chooser">שלח דואר אלקטרוני&#8230;</string>
 
     <!-- ======================= Filters ====================== -->
-    <string name="filter_name_and">And</string>
-    <string name="filter_name_not">Not</string>
-    <string name="filter_name_or">Or</string>
-    <string name="filter_name_receipt_category">Category</string>
-    <string name="filter_name_receipt_reimbursable">Is Reimbursable</string>
-    <string name="filter_name_receipt_max_price">Max Price</string>
-    <string name="filter_name_receipt_min_price">Min Price</string>
-    <string name="filter_name_receipt_on_or_after">On Or After</string>
-    <string name="filter_name_receipt_on_or_before">On Or Before</string>
-    <string name="filter_name_receipt_selected">Is Selected</string>
-    <string name="filter_name_trip_ends_on_or_after">Ends On Or After</string>
-    <string name="filter_name_trip_ends_on_or_before">Ends On Or Before</string>
-    <string name="filter_name_trip_max_price">Max Price</string>
-    <string name="filter_name_trip_min_price">Min Price</string>
-    <string name="filter_name_trip_starts_on_or_after">Starts On Or After</string>
-    <string name="filter_name_trip_starts_on_or_before">Starts On Or Before</string>
+    <string name="filter_name_and">ו</string>
+    <string name="filter_name_not">גם</string>
+    <string name="filter_name_or">או</string>
+    <string name="filter_name_receipt_category">קטגרוריה</string>
+    <string name="filter_name_receipt_reimbursable">בר החזר</string>
+    <string name="filter_name_receipt_max_price">מחיר מקסימלי</string>
+    <string name="filter_name_receipt_min_price">מחיר מינימלי</string>
+    <string name="filter_name_receipt_on_or_after">בזמן או אחרי הזמן</string>
+    <string name="filter_name_receipt_on_or_before">בזמן או לפני הזמן</string>
+    <string name="filter_name_receipt_selected">מסומן</string>
+    <string name="filter_name_trip_ends_on_or_after">נגמר ב או אחרי</string>
+    <string name="filter_name_trip_ends_on_or_before">נגמר ב או לפני</string>
+    <string name="filter_name_trip_max_price">מחיר מקסימלי</string>
+    <string name="filter_name_trip_min_price">מחיר מינימלי</string>
+    <string name="filter_name_trip_starts_on_or_after">מתחיל ב או אחרי</string>
+    <string name="filter_name_trip_starts_on_or_before">מתחיל ב או לפני</string>
 
     <!-- =================== Payment Methods =====+============= -->
-    <string name="payment_method">Payment Method</string>
-    <string name="payment_methods">Payment Methods</string>
-    <string name="payment_method_add">Add Payment Method</string>
-    <string name="payment_method_edit">Edit Payment Method</string>
-    <string name="payment_method_default_cash">Cash</string>
-    <string name="payment_method_default_check">Check</string>
-    <string name="payment_method_default_personal_card">Personal Card</string>
-    <string name="payment_method_default_corporate_card">Corporate Card</string>
+    <string name="payment_method">אמצעי תשלום</string>
+    <string name="payment_methods">אמצי תשלום</string>
+    <string name="payment_method_add">הוסף אמצעי תשלום</string>
+    <string name="payment_method_edit">ערוך אמצעי תשלום</string>
+    <string name="payment_method_default_cash">מזומן</string>
+    <string name="payment_method_default_check">צ׳ק</string>
+    <string name="payment_method_default_personal_card">כרטיס אשראי אישי</string>
+    <string name="payment_method_default_corporate_card">כרטיס אשראי חברה</string>
 
     <!-- =================== Payment Methods =================== -->
-    <string name="purchase_succeeded">Successfully completed the purchase</string>
-    <string name="purchase_unavailable">Unable to retrieve purchase information</string>
-    <string name="purchase_failed">Failed to complete the purchase</string>
+    <string name="purchase_succeeded">הרכישה בוצעה בהצלחה</string>
+    <string name="purchase_unavailable">משיכת מידע לגבי הרכישה נכשלה</string>
+    <string name="purchase_failed">השלמת הרכישה נכשלה</string>
 
     <!-- ================== App Rating ==================== -->
-    <string name="rating_tooltip_text">Like Smart Receipts?</string>
-    <string name="leave_feedback_text">Would you like to leave us feedback?</string>
-    <string name="apprating_dialog_title">Like %s?</string>
-    <string name="apprating_dialog_message">Please consider leaving a review about it. As an independent developer, your reviews are my primary source of exposure and really help to encourage me to keep adding new features. Thanks!</string>
-    <string name="apprating_dialog_negative">No Thanks</string>
-    <string name="apprating_dialog_neutral">Maybe Later</string>
-    <string name="apprating_dialog_positive">Rate It Now!</string>
+    <string name="rating_tooltip_text">אוהב את Smart Receipts?</string>
+    <string name="leave_feedback_text">תרצה להשאיר לנו פידבק?</string>
+    <string name="apprating_dialog_title">אוהב את %s?</string>
+	    <string name="apprating_dialog_message">אנא שקול להשאיר ביקורת בחנות האפליקציות. בתור מפתח עצמאי, הביקורות שלך הן אמצעי החשיפה העיקרי שלי ויכולות מאוד לעזור לי לפתח פונקציונאליות נוספת. תודה!</string>
+    <string name="apprating_dialog_negative">לא תודה</string>
+    <string name="apprating_dialog_neutral">אולי אחר כך</string>
+    <string name="apprating_dialog_positive">דרג עכשיו!</string>
 
     <!-- ================== Tooltip messages ==================== -->
     <string name="tooltip_generate_info_message">Use the \'Generate\' tab to create your reports</string>


### PR DESCRIPTION
Hey @wbaumann,

All done with the Hebrew translations!

A few things I didn't translate:

1. The `preference_defaults.xml` file, since it seems to contain only boolean fields. 
2. Any fields with `translatable="false"` in them.
3. Any mention of the app's name - it doesn't translate well to Hebrew, in my opinion. קבלות חכמות is the literal translation (Ka-ba-lot Kha-kha-mot, phonetically - ["kha" is the very Hebrew-ey "heit" sound](https://en.wikipedia.org/wiki/Heth#Hebrew_%E1%B8%A4et)), which sounds a bit like a marketing scheme by a not-so-clever advertising agency. I think it's best we leave it at that until we have a better name.
4. The `pref_about_about_dialogMessage` field - due to #3 above.
5. The `pref_about_terms_dialogMessage` field (the GNU Affero license) - I think translating messes up the subtle legalese involved, so I left it at that for now. There's probably a good translation somewhere - I just can't seem to find it! 

Cheers,

Tom