### PR TITLE
Fixed Categories Summation Table

### DIFF
--- a/app/src/main/java/co/smartreceipts/android/model/impl/ImmutableNetPriceImpl.java
+++ b/app/src/main/java/co/smartreceipts/android/model/impl/ImmutableNetPriceImpl.java
@@ -9,6 +9,7 @@ import com.google.common.base.Preconditions;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -144,11 +145,7 @@ public final class ImmutableNetPriceImpl extends AbstractPriceImpl {
     @NonNull
     @Override
     public String getDecimalFormattedPrice() {
-        if (areAllExchangeRatesValid) {
-            return ModelUtils.getDecimalFormattedValue(totalPrice);
-        } else {
-            return getCurrencyCodeFormattedStringFromMap(currencyToPriceMap);
-        }
+        return decimalFormattedPrice;
     }
 
     @NonNull
@@ -160,11 +157,7 @@ public final class ImmutableNetPriceImpl extends AbstractPriceImpl {
     @NonNull
     @Override
     public String getCurrencyCodeFormattedPrice() {
-        if (notExchangedPriceMap.size() > 1) {
-            return getCurrencyCodeFormattedStringFromMap(notExchangedPriceMap);
-        } else {
-            return ModelUtils.getCurrencyCodeFormattedValue(totalPrice, currency);
-        }
+        return currencyCodeFormattedPrice;
     }
 
     @NonNull
@@ -217,6 +210,10 @@ public final class ImmutableNetPriceImpl extends AbstractPriceImpl {
         return 0;
     }
 
+    public Map<PriceCurrency, BigDecimal> getImmutableOriginalPrices() {
+        return Collections.unmodifiableMap(notExchangedPriceMap);
+    }
+
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeString(currency.getCurrencyCode());
@@ -231,7 +228,7 @@ public final class ImmutableNetPriceImpl extends AbstractPriceImpl {
     }
 
     @NonNull
-    public String calculateDecimalFormattedPrice() {
+    private String calculateDecimalFormattedPrice() {
         if (areAllExchangeRatesValid) {
             return ModelUtils.getDecimalFormattedValue(totalPrice);
         } else {
@@ -253,12 +250,8 @@ public final class ImmutableNetPriceImpl extends AbstractPriceImpl {
     }
 
     @NonNull
-    public String calculateCurrencyCodeFormattedPrice() {
-        if (notExchangedPriceMap.size() > 1) {
+    private String calculateCurrencyCodeFormattedPrice() {
             return getCurrencyCodeFormattedStringFromMap(notExchangedPriceMap);
-        } else {
-            return ModelUtils.getCurrencyCodeFormattedValue(totalPrice, currency);
-        }
     }
 
     private void writeMapToParcel(@NonNull Parcel dest, @NonNull Map<PriceCurrency, BigDecimal> map) {

--- a/app/src/main/java/co/smartreceipts/android/persistence/database/controllers/grouping/results/SumCategoryGroupingResult.java
+++ b/app/src/main/java/co/smartreceipts/android/persistence/database/controllers/grouping/results/SumCategoryGroupingResult.java
@@ -4,27 +4,30 @@ import android.support.annotation.NonNull;
 
 import com.google.common.base.Preconditions;
 
-import co.smartreceipts.android.model.Category;
-import co.smartreceipts.android.model.Price;
 import co.smartreceipts.android.currency.PriceCurrency;
+import co.smartreceipts.android.model.Category;
+import co.smartreceipts.android.model.impl.ImmutableNetPriceImpl;
 
 public class SumCategoryGroupingResult {
 
     private final Category category;
 
-    private final PriceCurrency currency;
+    private final PriceCurrency baseCurrency;
 
-    private final Price price, tax;
+    private final ImmutableNetPriceImpl netPrice, netTax;
 
     private final int receiptsCount;
 
-    public SumCategoryGroupingResult(@NonNull Category category, @NonNull PriceCurrency currency,
-                                     @NonNull Price price, @NonNull Price tax, int receiptsCount) {
+    private final boolean isMultiCurrency;
+
+    public SumCategoryGroupingResult(@NonNull Category category, @NonNull PriceCurrency baseCurrency,
+                                     @NonNull ImmutableNetPriceImpl netPrice, @NonNull ImmutableNetPriceImpl netTax, int receiptsCount) {
         this.category = Preconditions.checkNotNull(category);
-        this.currency = Preconditions.checkNotNull(currency);
-        this.price = Preconditions.checkNotNull(price);
-        this.tax = Preconditions.checkNotNull(tax);
+        this.baseCurrency = Preconditions.checkNotNull(baseCurrency);
+        this.netPrice = Preconditions.checkNotNull(netPrice);
+        this.netTax = Preconditions.checkNotNull(netTax);
         this.receiptsCount = receiptsCount;
+        this.isMultiCurrency = netPrice.getImmutableOriginalPrices().keySet().size() > 1;
     }
 
     @NonNull
@@ -33,21 +36,25 @@ public class SumCategoryGroupingResult {
     }
 
     @NonNull
-    public PriceCurrency getCurrency() {
-        return currency;
+    public PriceCurrency getBaseCurrency() {
+        return baseCurrency;
     }
 
     @NonNull
-    public Price getPrice() {
-        return price;
+    public ImmutableNetPriceImpl getNetPrice() {
+        return netPrice;
     }
 
     @NonNull
-    public Price getTax() {
-        return tax;
+    public ImmutableNetPriceImpl getNetTax() {
+        return netTax;
     }
 
     public int getReceiptsCount() {
         return receiptsCount;
+    }
+
+    public boolean isMultiCurrency() {
+        return isMultiCurrency;
     }
 }

--- a/app/src/main/java/co/smartreceipts/android/workers/EmailAssistant.java
+++ b/app/src/main/java/co/smartreceipts/android/workers/EmailAssistant.java
@@ -328,7 +328,14 @@ public class EmailAssistant {
                                 .toList()
                                 .blockingGet();
 
-                        final List<Column<SumCategoryGroupingResult>> categoryColumns = new CategoryColumnDefinitions(reportResourcesManager)
+                        boolean isMultiCurrency = false;
+                        for (SumCategoryGroupingResult sumCategoryGroupingResult : sumCategoryGroupingResults) {
+                            if (sumCategoryGroupingResult.isMultiCurrency()) {
+                                isMultiCurrency = true;
+                                break;
+                            }
+                        }
+                        final List<Column<SumCategoryGroupingResult>> categoryColumns = new CategoryColumnDefinitions(reportResourcesManager, isMultiCurrency)
                                 .getAllColumns();
 
                         data += "\n\n";

--- a/app/src/main/java/co/smartreceipts/android/workers/reports/pdf/PdfBoxFullPdfReport.java
+++ b/app/src/main/java/co/smartreceipts/android/workers/reports/pdf/PdfBoxFullPdfReport.java
@@ -47,9 +47,17 @@ public class PdfBoxFullPdfReport extends PdfBoxAbstractReport {
         final List<Column<Distance>> distanceColumns = distanceColumnDefinitions.getAllColumns();
 
         // Categories Summation Table
-        final List<Column<SumCategoryGroupingResult>> categoryColumns = new CategoryColumnDefinitions(getReportResourcesManager())
-                .getAllColumns();
         final List<SumCategoryGroupingResult> categories = groupingController.getSummationByCategory(trip).toList().blockingGet();
+
+        boolean isMultiCurrency = false;
+        for (SumCategoryGroupingResult categorySummation : categories) {
+            if (categorySummation.isMultiCurrency()) {
+                isMultiCurrency = true;
+                break;
+            }
+        }
+        final List<Column<SumCategoryGroupingResult>> categoryColumns = new CategoryColumnDefinitions(getReportResourcesManager(), isMultiCurrency)
+                .getAllColumns();
 
         // Grouping by Category Receipts Tables
         final List<CategoryGroupingResult> groupingResults = groupingController.getReceiptsGroupedByCategory(trip).toList().blockingGet();

--- a/app/src/main/kotlin/co/smartreceipts/android/model/impl/columns/categories/CategoryExchangedPriceColumn.kt
+++ b/app/src/main/kotlin/co/smartreceipts/android/model/impl/columns/categories/CategoryExchangedPriceColumn.kt
@@ -8,27 +8,31 @@ import co.smartreceipts.android.sync.model.SyncState
 import java.util.*
 
 
-class CategoryCurrencyColumn(id: Int, syncState: SyncState) :
+class CategoryExchangedPriceColumn(id: Int, syncState: SyncState) :
     AbstractColumnImpl<SumCategoryGroupingResult>(
         id,
-        CategoryColumnDefinitions.ActualDefinition.CURRENCY,
+        CategoryColumnDefinitions.ActualDefinition.PRICE_EXCHANGED,
         syncState
     ) {
 
-    override fun getValue(sumCategoryGroupingResult: SumCategoryGroupingResult): String =
-        sumCategoryGroupingResult.currency.currencyCode
+    override fun getValue(sumCategoryGroupingResult: SumCategoryGroupingResult): String {
+        val price = sumCategoryGroupingResult.netPrice
+        return price.currency.currencyCode + price.decimalFormattedPrice
+    }
 
     override fun getFooter(rows: List<SumCategoryGroupingResult>): String {
         return if (!rows.isEmpty()) {
-            val tripCurrency = rows[0].currency
+            val tripCurrency = rows[0].baseCurrency
             val prices = ArrayList<Price>()
             for (row in rows) {
-                prices.add(row.price)
+                prices.add(row.netPrice)
             }
-            PriceBuilderFactory().setPrices(prices, tripCurrency).build().currencyCode
+
+            val total = PriceBuilderFactory().setPrices(prices, tripCurrency).build()
+
+            total.currencyCodeFormattedPrice
         } else {
             ""
         }
     }
-
 }

--- a/app/src/main/kotlin/co/smartreceipts/android/model/impl/columns/categories/CategoryTaxColumn.kt
+++ b/app/src/main/kotlin/co/smartreceipts/android/model/impl/columns/categories/CategoryTaxColumn.kt
@@ -16,19 +16,21 @@ class CategoryTaxColumn(id: Int, syncState: SyncState) :
     ) {
 
     override fun getValue(sumCategoryGroupingResult: SumCategoryGroupingResult): String? =
-        sumCategoryGroupingResult.tax.decimalFormattedPrice
+        sumCategoryGroupingResult.netTax.currencyCodeFormattedPrice
 
     override fun getFooter(rows: List<SumCategoryGroupingResult>): String {
         return if (!rows.isEmpty()) {
-            val tripCurrency = rows[0].currency
             val prices = ArrayList<Price>()
+
             for (row in rows) {
-                prices.add(row.tax)
+                for (entry in row.netTax.immutableOriginalPrices.entries) {
+                    prices.add(PriceBuilderFactory().setCurrency(entry.key).setPrice(entry.value).build())
+                }
             }
 
-            val total = PriceBuilderFactory().setPrices(prices, tripCurrency).build()
+            val total = PriceBuilderFactory().setPrices(prices, rows[0].baseCurrency).build()
 
-            if (total.currencyCodeCount == 1) total.decimalFormattedPrice else total.currencyCodeFormattedPrice
+            total.currencyCodeFormattedPrice
         } else {
             ""
         }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -412,6 +412,8 @@
     <string name="category_price_field">Preis</string>
     <string name="category_tax_field">Steuer</string>
     <string name="category_currency_field">Währung</string>
+    <string name="category_price_exchanged_field">Preis (getauscht)</string>
+
 
     <string name="receipt_dialog_action_edit">Beleg bearbeiten</string>
     <string name="receipt_dialog_action_view">Ansicht Beleg %s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -412,6 +412,8 @@
     <string name="category_price_field">Precio</string>
     <string name="category_tax_field">Impuesto</string>
     <string name="category_currency_field">Moneda</string>
+    <string name="category_price_exchanged_field">Precio (al cambio)</string>
+
 
     <string name="receipt_dialog_action_edit">Editar recibo</string>
     <string name="receipt_dialog_action_view">Ver recibo %s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -412,6 +412,8 @@
     <string name="category_price_field">Prix</string>
     <string name="category_tax_field">Taxe</string>
     <string name="category_currency_field">Devise</string>
+    <string name="category_price_exchanged_field">Prix (Échangé)</string>
+
 
     <string name="receipt_dialog_action_edit">Modifier le reçu</string>
     <string name="receipt_dialog_action_view">Afficher le reçu %s</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -315,6 +315,7 @@
     <string name="category_price_field">מחיר</string>
     <string name="category_tax_field">מס</string>
     <string name="category_currency_field">מטבע</string>
+    <string name="category_price_exchanged_field">מחיר לאחר המרה</string>
 
     <!-- ===================== backup menu ======================== -->
     <string name="backups">גיבויים</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -412,6 +412,8 @@
     <string name="category_price_field">Preço</string>
     <string name="category_tax_field">Impostos</string>
     <string name="category_currency_field">Moeda</string>
+    <string name="category_price_exchanged_field">Preço (com câmbio)</string>
+
 
     <string name="receipt_dialog_action_edit">Editar recibo</string>
     <string name="receipt_dialog_action_view">Visualizar recibo %s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -414,6 +414,8 @@
     <string name="category_price_field">Цена</string>
     <string name="category_tax_field">Налог</string>
     <string name="category_currency_field">Валюта</string>
+    <string name="category_price_exchanged_field">Цена (после обмена)</string>
+
 
     <string name="receipt_dialog_action_edit">Редактировать чек</string>
     <string name="receipt_dialog_action_view">Просмотреть чек %s</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -414,6 +414,8 @@
     <string name="category_price_field">Вартість</string>
     <string name="category_tax_field">Податок</string>
     <string name="category_currency_field">Валюта</string>
+    <string name="category_price_exchanged_field">Вартість (після обміну)</string>
+
 
     <string name="receipt_dialog_action_edit">Редагувати чек</string>
     <string name="receipt_dialog_action_view">Переглянути чек %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -427,6 +427,8 @@
     <string name="category_price_field">Price</string>
     <string name="category_tax_field">Tax</string>
     <string name="category_currency_field">Currency</string>
+    <string name="category_price_exchanged_field">Price (Exchanged)</string>
+
 
     <string name="receipt_dialog_action_edit">Edit Receipt</string>
     <string name="receipt_dialog_action_view">View Receipt %s</string>

--- a/app/src/test/java/co/smartreceipts/android/report/InteractivePdfBoxTest.java
+++ b/app/src/test/java/co/smartreceipts/android/report/InteractivePdfBoxTest.java
@@ -37,7 +37,7 @@ import co.smartreceipts.android.model.Receipt;
 import co.smartreceipts.android.model.Trip;
 import co.smartreceipts.android.model.factory.ReceiptBuilderFactory;
 import co.smartreceipts.android.model.impl.columns.categories.CategoryCodeColumn;
-import co.smartreceipts.android.model.impl.columns.categories.CategoryCurrencyColumn;
+import co.smartreceipts.android.model.impl.columns.categories.CategoryExchangedPriceColumn;
 import co.smartreceipts.android.model.impl.columns.categories.CategoryNameColumn;
 import co.smartreceipts.android.model.impl.columns.categories.CategoryPriceColumn;
 import co.smartreceipts.android.model.impl.columns.categories.CategoryTaxColumn;
@@ -500,7 +500,7 @@ public class InteractivePdfBoxTest {
         summationColumns.add(new CategoryCodeColumn(2, new DefaultSyncState()));
         summationColumns.add(new CategoryPriceColumn(3, new DefaultSyncState()));
         summationColumns.add(new CategoryTaxColumn(4, new DefaultSyncState()));
-        summationColumns.add(new CategoryCurrencyColumn(5, new DefaultSyncState()));
+        summationColumns.add(new CategoryExchangedPriceColumn(5, new DefaultSyncState()));
 
         pdfBoxReportFile.addSection(pdfBoxReportFile.createReceiptsTableSection(trip, receipts,
                 receiptColumns, Collections.<Distance>emptyList(), distanceColumns,

--- a/app/src/test/kotlin/co/smartreceipts/android/model/impl/columns/categories/CategoryColumnDefinitionsTest.kt
+++ b/app/src/test/kotlin/co/smartreceipts/android/model/impl/columns/categories/CategoryColumnDefinitionsTest.kt
@@ -1,0 +1,54 @@
+package co.smartreceipts.android.model.impl.columns.categories
+
+import co.smartreceipts.android.model.Column
+import co.smartreceipts.android.sync.model.impl.DefaultSyncState
+import co.smartreceipts.android.workers.reports.ReportResourcesManager
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.whenever
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+
+class CategoryColumnDefinitionsTest {
+
+    // Class under test
+    private lateinit var categoryColumnDefinitions: CategoryColumnDefinitions
+
+    @Mock
+    private lateinit var reportResourceManager: ReportResourcesManager
+
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+
+        whenever(reportResourceManager.getFlexString(any<Int>())).thenReturn(anyString)
+    }
+
+    @Test
+    fun checkWhenMultiCurrency() {
+        categoryColumnDefinitions = CategoryColumnDefinitions(reportResourceManager, true)
+
+        val allColumns = categoryColumnDefinitions.allColumns
+
+        assert(allColumns.isNotEmpty())
+        assert(allColumns.size == CategoryColumnDefinitions.ActualDefinition.values().size)
+        assert(allColumns.contains(CategoryExchangedPriceColumn(Column.UNKNOWN_ID, DefaultSyncState())))
+    }
+
+    @Test
+    fun checkWhenNotMultiCurrency() {
+        categoryColumnDefinitions = CategoryColumnDefinitions(reportResourceManager, false)
+
+        val allColumns = categoryColumnDefinitions.allColumns
+
+        assert(allColumns.isNotEmpty())
+        assert(allColumns.size == CategoryColumnDefinitions.ActualDefinition.values().size - 1)
+        assert(!allColumns.contains(CategoryExchangedPriceColumn(Column.UNKNOWN_ID, DefaultSyncState())))
+    }
+
+    companion object {
+        private const val anyString = "string"
+    }
+}


### PR DESCRIPTION
* Now `Price` and `Tax` columns show currency code formatted not exchanged price values.
* I also removed the `Currency` column because `Price` column always includes currency code.
* `Price(Exchanged)` column now appears just when receipts have not the same currency.

I thought about using the `ReceiptBuilderFactory` method as you suggested before but now looks like category summation columns (especially price columns) behaves in a different way then receipt price columns. The reason is representing `ImmutableNetPriceImpl`, and it takes special actions to extract original non-exchanged prices for `Price` column.