### PR TITLE
Updated our date processing to use a dedicated date formatter

### DIFF
--- a/app/src/androidTest/java/co/smartreceipts/android/test/espresso/UpgradeFromKnownDatabaseValidator.kt
+++ b/app/src/androidTest/java/co/smartreceipts/android/test/espresso/UpgradeFromKnownDatabaseValidator.kt
@@ -9,6 +9,7 @@ import android.support.test.runner.AndroidJUnit4
 import android.util.Log
 import co.smartreceipts.android.SmartReceiptsApplication
 import co.smartreceipts.android.activities.SmartReceiptsActivity
+import co.smartreceipts.android.date.DateFormatter
 import co.smartreceipts.android.test.runner.BeforeApplicationOnCreate
 import co.smartreceipts.android.test.utils.TestLocaleToggler
 import co.smartreceipts.android.test.utils.TestResourceReader
@@ -115,11 +116,14 @@ abstract class UpgradeFromKnownDatabaseValidator {
 
     private lateinit var context: Context
 
+    private lateinit var dateFormatter: DateFormatter
+
     @Before
     @CallSuper
     fun setUp() {
         val application = activityTestRule.activity.application as SmartReceiptsApplication
         databaseHelper = application.databaseHelper
+        dateFormatter = application.dateFormatter
 
         // Set the Locale to en-US for consistency purposes
         val nonLocalizedContext = InstrumentationRegistry.getInstrumentation().targetContext
@@ -228,8 +232,8 @@ abstract class UpgradeFromKnownDatabaseValidator {
         assertEquals(1, report1.id)
         assertEquals("Report 1", report1.name)
         assertEquals("Report 1", report1.directory.name)
-        assertEquals("11/16/16", report1.getFormattedStartDate(context, "/"))
-        assertEquals("11/20/16", report1.getFormattedEndDate(context, "/"))
+        assertEquals("11/16/16", dateFormatter.getFormattedDate(report1.startDate, report1.startTimeZone))
+        assertEquals("11/20/16", dateFormatter.getFormattedDate(report1.endDate, report1.endTimeZone))
         assertEquals("$45.00", report1.price.currencyFormattedPrice)
         assertEquals("USD", report1.tripCurrency.currencyCode)
         assertEquals("Comment", report1.comment)
@@ -255,8 +259,8 @@ abstract class UpgradeFromKnownDatabaseValidator {
         assertEquals(2, report2.id)
         assertEquals("Report 2", report2.name)
         assertEquals("Report 2", report2.directory.name)
-        assertEquals("11/17/16", report2.getFormattedStartDate(context, "/"))
-        assertEquals("11/20/16", report2.getFormattedEndDate(context, "/"))
+        assertEquals("11/17/16", dateFormatter.getFormattedDate(report2.startDate, report2.startTimeZone))
+        assertEquals("11/20/16", dateFormatter.getFormattedDate(report2.endDate, report2.endTimeZone))
         assertEquals("$50.00", report2.price.currencyFormattedPrice)
         assertEquals("USD", report2.tripCurrency.currencyCode)
         assertEquals("", report2.comment)
@@ -288,8 +292,8 @@ abstract class UpgradeFromKnownDatabaseValidator {
         assertEquals(3, report3.id)
         assertEquals("Report 3", report3.name)
         assertEquals("Report 3", report3.directory.name)
-        assertEquals("11/17/16", report3.getFormattedStartDate(context, "/"))
-        assertEquals("11/20/16", report3.getFormattedEndDate(context, "/"))
+        assertEquals("11/17/16", dateFormatter.getFormattedDate(report3.startDate, report3.startTimeZone))
+        assertEquals("11/20/16", dateFormatter.getFormattedDate(report3.endDate, report3.endTimeZone))
         assertEquals("$68.60", report3.price.currencyFormattedPrice)
         assertEquals("USD", report3.tripCurrency.currencyCode)
         assertEquals("", report3.comment)
@@ -324,7 +328,7 @@ abstract class UpgradeFromKnownDatabaseValidator {
         assertEquals("$3.00", distance.price.currencyFormattedPrice)
         assertEquals("USD", distance.price.currencyCode)
         assertEquals("Location", distance.location)
-        assertEquals("11/20/16", distance.getFormattedDate(context, "/"))
+        assertEquals("11/20/16", dateFormatter.getFormattedDate(distance.date, distance.timeZone))
         assertEquals("Comment", distance.comment)
 
         allDistances.addAll(report3Distances)
@@ -377,7 +381,7 @@ abstract class UpgradeFromKnownDatabaseValidator {
         assertEquals("USD", receipt.price.currencyCode)
         assertEquals("$0.00", receipt.tax.currencyFormattedPrice)
         assertEquals("USD", receipt.tax.currencyCode)
-        assertEquals(date, receipt.getFormattedDate(context, "/"))
+        assertEquals(date, dateFormatter.getFormattedDate(receipt.date, receipt.timeZone))
         assertEquals(category, receipt.category)
         assertEquals("", receipt.comment)
         assertEquals(PaymentMethod.NONE, receipt.paymentMethod)
@@ -396,7 +400,7 @@ abstract class UpgradeFromKnownDatabaseValidator {
         assertEquals("USD", receipt.price.currencyCode)
         assertEquals("$1.50", receipt.tax.currencyFormattedPrice)
         assertEquals("USD", receipt.tax.currencyCode)
-        assertEquals(date, receipt.getFormattedDate(context, "/"))
+        assertEquals(date, dateFormatter.getFormattedDate(receipt.date, receipt.timeZone))
         assertEquals(category, receipt.category)
         assertEquals("", receipt.comment)
         assertEquals(paymentMethod, receipt.paymentMethod)
@@ -415,7 +419,7 @@ abstract class UpgradeFromKnownDatabaseValidator {
         assertEquals("USD", receipt.price.currencyCode)
         assertEquals("$0.00", receipt.tax.currencyFormattedPrice)
         assertEquals("USD", receipt.tax.currencyCode)
-        assertEquals(date, receipt.getFormattedDate(context, "/"))
+        assertEquals(date, dateFormatter.getFormattedDate(receipt.date, receipt.timeZone))
         assertEquals(category, receipt.category)
         assertEquals("", receipt.comment)
         assertEquals(PaymentMethod.NONE, receipt.paymentMethod)
@@ -437,7 +441,7 @@ abstract class UpgradeFromKnownDatabaseValidator {
         assertTrue(receipt.price.exchangeRate.supportsExchangeRateFor("USD"))
         assertEquals("2.000000", receipt.price.exchangeRate.getDecimalFormattedExchangeRate("USD"))
         assertEquals("EUR", receipt.tax.currencyCode)
-        assertEquals("11/20/16", receipt.getFormattedDate(context, "/"))
+        assertEquals("11/20/16", dateFormatter.getFormattedDate(receipt.date, receipt.timeZone))
         assertEquals(category, receipt.category)
         assertEquals("Comment", receipt.comment)
         assertEquals(PaymentMethod.NONE, receipt.paymentMethod)

--- a/app/src/main/java/co/smartreceipts/android/SmartReceiptsApplication.java
+++ b/app/src/main/java/co/smartreceipts/android/SmartReceiptsApplication.java
@@ -18,6 +18,7 @@ import javax.inject.Inject;
 import co.smartreceipts.android.analytics.Analytics;
 import co.smartreceipts.android.analytics.crash.CrashReporter;
 import co.smartreceipts.android.aws.cognito.CognitoManager;
+import co.smartreceipts.android.date.DateFormatter;
 import co.smartreceipts.android.di.AppComponent;
 import co.smartreceipts.android.di.BaseAppModule;
 import co.smartreceipts.android.di.DaggerAppComponent;
@@ -64,9 +65,6 @@ public class SmartReceiptsApplication extends Application implements HasActivity
 
     @Inject
     DispatchingAndroidInjector<Service> serviceInjector;
-
-    @Inject
-    PersistenceManager persistenceManager;
 
     @Inject
     DatabaseHelper databaseHelper;
@@ -124,6 +122,9 @@ public class SmartReceiptsApplication extends Application implements HasActivity
 
     @Inject
     MemoryLeakMonitor memoryLeakMonitor;
+
+    @Inject
+    DateFormatter dateFormatter;
 
     private AppComponent appComponent;
 
@@ -213,6 +214,17 @@ public class SmartReceiptsApplication extends Application implements HasActivity
     @VisibleForTesting
     public DatabaseHelper getDatabaseHelper() {
         return databaseHelper;
+    }
+
+    /**
+     * Similar to our use of {@link #getDatabaseHelper()} above, we supply this getter for our
+     * espresso test modules to simplify how we access this content
+     *
+     * @return the {@link DateFormatter}
+     */
+    @VisibleForTesting
+    public DateFormatter getDateFormatter() {
+        return dateFormatter;
     }
 
     private void init() {

--- a/app/src/main/java/co/smartreceipts/android/date/DateFormatThreadLocal.kt
+++ b/app/src/main/java/co/smartreceipts/android/date/DateFormatThreadLocal.kt
@@ -1,0 +1,17 @@
+package co.smartreceipts.android.date
+
+import java.text.DateFormat
+
+
+/**
+ * Since the [DateFormat] class in Java is not thread safe by default, we take advantage of Java's
+ * [ThreadLocal] to optimize for both memory and performance.
+ *
+ * @see <a href="DateFormat with Multiple Threads">https://stackoverflow.com/a/4021932/4250037</a>
+ */
+class DateFormatThreadLocal(private val initialValue: DateFormat) : ThreadLocal<DateFormat>() {
+
+    override fun initialValue(): DateFormat {
+        return initialValue
+    }
+}

--- a/app/src/main/java/co/smartreceipts/android/date/DateFormatter.kt
+++ b/app/src/main/java/co/smartreceipts/android/date/DateFormatter.kt
@@ -1,0 +1,87 @@
+package co.smartreceipts.android.date
+
+import android.content.Context
+import co.smartreceipts.android.di.scopes.ApplicationScope
+import co.smartreceipts.android.settings.UserPreferenceManager
+import co.smartreceipts.android.settings.catalog.UserPreference
+import java.sql.Date
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import kotlin.collections.HashMap
+
+
+/**
+ * A standard Date Formatter instance, which we can use to ensure that all dates within the app are
+ * properly formatted based on the timezone, user's locale, and user's default settings in the app.
+ */
+@ApplicationScope
+class DateFormatter @Inject constructor(private val context: Context,
+                                        private val userPreferenceManager: UserPreferenceManager) {
+
+    private val threadLocalCache = ConcurrentHashMap<DateFormatMetadata, DateFormatThreadLocal>()
+
+    /**
+     * Gets a formatted version of a date based for a particular timezone. We also apply the user's
+     * in-app preferences to ensure this value appears in the desired format. For example, we might
+     * expect the US Locale to return a result like "08/23/2014" by default for August 23rd, 2014,
+     * if we set the separator as "/".
+     *
+     * @param displayableDate a [DisplayableDate]
+     *
+     * @return the formatted date string for the provided date
+     */
+    fun getFormattedDate(displayableDate: DisplayableDate): String {
+        return getFormattedDate(displayableDate.date, displayableDate.timeZone)
+    }
+
+    /**
+     * Gets a formatted version of a date based for a particular timezone. We also apply the user's
+     * in-app preferences to ensure this value appears in the desired format. For example, we might
+     * expect the US Locale to return a result like "08/23/2014" by default for August 23rd, 2014,
+     * if we set the separator as "/".
+     *
+     * @param date the [java.util.Date] to format
+     * @param timeZone the [TimeZone] to use for this date
+     *
+     * @return the formatted date string for the provided date
+     */
+    fun getFormattedDate(date: java.util.Date, timeZone: TimeZone): String {
+        return getFormattedDate(Date(date.time), timeZone)
+    }
+
+    /**
+     * Gets a formatted version of a date based for a particular timezone. We also apply the user's
+     * in-app preferences to ensure this value appears in the desired format. For example, we might
+     * expect the US Locale to return a result like "08/23/2014" by default for August 23rd, 2014,
+     * if we set the separator as "/".
+     *
+     * @param date the [Date] to format
+     * @param timeZone the [TimeZone] to use for this date
+     *
+     * @return the formatted date string for the provided date
+     */
+    fun getFormattedDate(date: Date, timeZone: TimeZone): String {
+        // Build a set of metadata for this item to ensure that we can cache the results
+        val dateFormatMetadata = DateFormatMetadata(timeZone)
+
+        // Next, leverage a ThreadLocal to fetch a thread safe handle to our date format
+        val dateFormatThreadLocal = threadLocalCache.getOrPut(dateFormatMetadata) {
+            val format = android.text.format.DateFormat.getDateFormat(context)
+            format.timeZone = timeZone // Hack to shift the timezone appropriately
+            return@getOrPut DateFormatThreadLocal(format)
+        }
+        val dateFormat = dateFormatThreadLocal.get()
+        val formattedDate = dateFormat.format(date)
+
+        // Finally, replace our date separator instance with an appropriate one
+        val separator = userPreferenceManager[UserPreference.General.DateSeparator]
+        return formattedDate.replace(DateUtils.getDateSeparator(context), separator)
+    }
+
+    /**
+     * A private data class, which we use to track metadata that could influence our date formats
+     */
+    private data class DateFormatMetadata(private val timeZone: TimeZone)
+
+}

--- a/app/src/main/java/co/smartreceipts/android/date/DisplayableDate.kt
+++ b/app/src/main/java/co/smartreceipts/android/date/DisplayableDate.kt
@@ -1,0 +1,13 @@
+package co.smartreceipts.android.date
+
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+import java.sql.Date
+import java.util.*
+
+/**
+ * Contains the required metadata to display a date to the end user.
+ */
+@Parcelize
+data class DisplayableDate(val date: Date,
+                           val timeZone: TimeZone) : Parcelable

--- a/app/src/main/java/co/smartreceipts/android/fragments/GenerateReportFragment.java
+++ b/app/src/main/java/co/smartreceipts/android/fragments/GenerateReportFragment.java
@@ -21,6 +21,7 @@ import co.smartreceipts.android.R;
 import co.smartreceipts.android.activities.NavigationHandler;
 import co.smartreceipts.android.analytics.Analytics;
 import co.smartreceipts.android.analytics.events.Events;
+import co.smartreceipts.android.date.DateFormatter;
 import co.smartreceipts.android.model.Trip;
 import co.smartreceipts.android.persistence.PersistenceManager;
 import co.smartreceipts.android.purchases.wallet.PurchaseWallet;
@@ -55,8 +56,12 @@ public class GenerateReportFragment extends WBFragment implements View.OnClickLi
 
     @Inject
     UserPreferenceManager preferenceManager;
+
     @Inject
     ReportResourcesManager reportResourcesManager;
+
+    @Inject
+    DateFormatter dateFormatter;
 
     private CheckBox pdfFullCheckbox;
     private CheckBox pdfImagesCheckbox;
@@ -188,7 +193,7 @@ public class GenerateReportFragment extends WBFragment implements View.OnClickLi
         }
 
         final EmailAssistant emailAssistant = new EmailAssistant(getActivity(), navigationHandler,
-                reportResourcesManager, persistenceManager, trip, purchaseWallet);
+                reportResourcesManager, persistenceManager, trip, purchaseWallet, dateFormatter);
         emailAssistant.emailTrip(options);
     }
 }

--- a/app/src/main/java/co/smartreceipts/android/model/impl/columns/receipts/ReceiptColumnDefinitions.kt
+++ b/app/src/main/java/co/smartreceipts/android/model/impl/columns/receipts/ReceiptColumnDefinitions.kt
@@ -2,6 +2,7 @@ package co.smartreceipts.android.model.impl.columns.receipts
 
 import android.support.annotation.StringRes
 import co.smartreceipts.android.R
+import co.smartreceipts.android.date.DateFormatter
 import co.smartreceipts.android.model.*
 import co.smartreceipts.android.model.comparators.ColumnNameComparator
 import co.smartreceipts.android.model.impl.columns.AbstractColumnImpl
@@ -20,11 +21,12 @@ import kotlin.collections.ArrayList
  * Provides specific definitions for all [co.smartreceipts.android.model.Receipt] [co.smartreceipts.android.model.Column]
  * objects
  */
-class ReceiptColumnDefinitions @Inject
-constructor(
+class ReceiptColumnDefinitions @Inject constructor(
     private val reportResourcesManager: ReportResourcesManager,
-    private val preferences: UserPreferenceManager
+    private val preferences: UserPreferenceManager,
+    private val dateFormatter: DateFormatter
 ) : ColumnDefinitions<Receipt>, ColumnFinder {
+
     private val actualDefinitions = values()
 
     /**
@@ -171,15 +173,15 @@ constructor(
             CATEGORY_NAME -> ReceiptCategoryNameColumn(id, syncState, customOrderId, uuid)
             USER_ID -> SettingUserIdColumn(id, syncState, preferences, customOrderId, uuid)
             REPORT_NAME -> ReportNameColumn(id, syncState, customOrderId, uuid)
-            REPORT_START_DATE -> ReportStartDateColumn(id, syncState, localizedContext, preferences, customOrderId, uuid)
-            REPORT_END_DATE -> ReportEndDateColumn(id, syncState, localizedContext, preferences, customOrderId, uuid)
+            REPORT_START_DATE -> ReportStartDateColumn(id, syncState, dateFormatter, customOrderId, uuid)
+            REPORT_END_DATE -> ReportEndDateColumn(id, syncState, dateFormatter, customOrderId, uuid)
             REPORT_COMMENT -> ReportCommentColumn(id, syncState, customOrderId, uuid)
             REPORT_COST_CENTER -> ReportCostCenterColumn(id, syncState, customOrderId, uuid)
             IMAGE_FILE_NAME -> ReceiptFileNameColumn(id, syncState, customOrderId, uuid)
             IMAGE_PATH -> ReceiptFilePathColumn(id, syncState, customOrderId, uuid)
             COMMENT -> ReceiptCommentColumn(id, syncState, customOrderId, uuid)
             CURRENCY -> ReceiptCurrencyCodeColumn(id, syncState, customOrderId, uuid)
-            DATE -> ReceiptDateColumn(id, syncState, localizedContext, preferences, customOrderId, uuid)
+            DATE -> ReceiptDateColumn(id, syncState, dateFormatter, customOrderId, uuid)
             NAME -> ReceiptNameColumn(id, syncState, customOrderId, uuid)
             PRICE -> ReceiptPriceColumn(id, syncState, customOrderId, uuid)
             PRICE_MINUS_TAX -> ReceiptPriceMinusTaxColumn(id, syncState, preferences, customOrderId, uuid)

--- a/app/src/main/java/co/smartreceipts/android/model/impl/columns/receipts/ReceiptDateColumn.kt
+++ b/app/src/main/java/co/smartreceipts/android/model/impl/columns/receipts/ReceiptDateColumn.kt
@@ -1,11 +1,8 @@
 package co.smartreceipts.android.model.impl.columns.receipts
 
-import android.content.Context
-
+import co.smartreceipts.android.date.DateFormatter
 import co.smartreceipts.android.model.Receipt
 import co.smartreceipts.android.model.impl.columns.AbstractColumnImpl
-import co.smartreceipts.android.settings.UserPreferenceManager
-import co.smartreceipts.android.settings.catalog.UserPreference
 import co.smartreceipts.android.sync.model.SyncState
 import java.util.*
 
@@ -13,19 +10,18 @@ import java.util.*
  * Provides a column that returns the category code for a particular receipt
  */
 class ReceiptDateColumn(
-    id: Int, syncState: SyncState, private val localizedContext: Context,
-    private val preferences: UserPreferenceManager, customOrderId: Long, uuid: UUID
+        id: Int,
+        syncState: SyncState,
+        private val dateFormatter: DateFormatter,
+        customOrderId: Long,
+        uuid: UUID
 ) : AbstractColumnImpl<Receipt>(
-    id,
-    ReceiptColumnDefinitions.ActualDefinition.DATE,
-    syncState,
-    customOrderId,
-    uuid
+        id,
+        ReceiptColumnDefinitions.ActualDefinition.DATE,
+        syncState,
+        customOrderId,
+        uuid
 ) {
 
-    override fun getValue(rowItem: Receipt): String =
-        rowItem.getFormattedDate(
-            localizedContext,
-            preferences.get(UserPreference.General.DateSeparator)
-        )
+    override fun getValue(rowItem: Receipt): String = dateFormatter.getFormattedDate(rowItem.date, rowItem.timeZone)
 }

--- a/app/src/main/java/co/smartreceipts/android/model/impl/columns/receipts/ReportEndDateColumn.kt
+++ b/app/src/main/java/co/smartreceipts/android/model/impl/columns/receipts/ReportEndDateColumn.kt
@@ -1,11 +1,8 @@
 package co.smartreceipts.android.model.impl.columns.receipts
 
-import android.content.Context
-
+import co.smartreceipts.android.date.DateFormatter
 import co.smartreceipts.android.model.Receipt
 import co.smartreceipts.android.model.impl.columns.AbstractColumnImpl
-import co.smartreceipts.android.settings.UserPreferenceManager
-import co.smartreceipts.android.settings.catalog.UserPreference
 import co.smartreceipts.android.sync.model.SyncState
 import java.util.*
 
@@ -13,21 +10,23 @@ import java.util.*
  * Provides a column that returns the category code for a particular receipt
  */
 class ReportEndDateColumn(
-    id: Int, syncState: SyncState, private val context: Context,
-    private val preferences: UserPreferenceManager, customOrderId: Long, uuid: UUID
+        id: Int,
+        syncState: SyncState,
+        private val dateFormatter: DateFormatter,
+        customOrderId: Long,
+        uuid: UUID
 ) : AbstractColumnImpl<Receipt>(
-    id,
-    ReceiptColumnDefinitions.ActualDefinition.REPORT_END_DATE,
-    syncState,
-    customOrderId,
-    uuid
+        id,
+        ReceiptColumnDefinitions.ActualDefinition.REPORT_END_DATE,
+        syncState,
+        customOrderId,
+        uuid
 ) {
 
-    override fun getValue(rowItem: Receipt): String =
-        rowItem.trip.getFormattedEndDate(
-            context,
-            preferences.get(UserPreference.General.DateSeparator)
-        )
+    override fun getValue(rowItem: Receipt): String {
+        val trip = rowItem.trip
+        return dateFormatter.getFormattedDate(trip.endDate, trip.endTimeZone)
+    }
 
     override fun getFooter(rows: List<Receipt>): String =
         if (!rows.isEmpty()) getValue(rows[0])

--- a/app/src/main/java/co/smartreceipts/android/model/impl/columns/receipts/ReportStartDateColumn.kt
+++ b/app/src/main/java/co/smartreceipts/android/model/impl/columns/receipts/ReportStartDateColumn.kt
@@ -1,10 +1,8 @@
 package co.smartreceipts.android.model.impl.columns.receipts
 
-import android.content.Context
+import co.smartreceipts.android.date.DateFormatter
 import co.smartreceipts.android.model.Receipt
 import co.smartreceipts.android.model.impl.columns.AbstractColumnImpl
-import co.smartreceipts.android.settings.UserPreferenceManager
-import co.smartreceipts.android.settings.catalog.UserPreference
 import co.smartreceipts.android.sync.model.SyncState
 import java.util.*
 
@@ -12,21 +10,23 @@ import java.util.*
  * Provides a column that returns the category code for a particular receipt
  */
 class ReportStartDateColumn(
-    id: Int, syncState: SyncState, private val localizedContext: Context,
-    private val preferences: UserPreferenceManager, customOrderId: Long, uuid: UUID
+        id: Int,
+        syncState: SyncState,
+        private val dateFormatter: DateFormatter,
+        customOrderId: Long,
+        uuid: UUID
 ) : AbstractColumnImpl<Receipt>(
-    id,
-    ReceiptColumnDefinitions.ActualDefinition.REPORT_START_DATE,
-    syncState,
-    customOrderId,
-    uuid
+        id,
+        ReceiptColumnDefinitions.ActualDefinition.REPORT_START_DATE,
+        syncState,
+        customOrderId,
+        uuid
 ) {
 
-    override fun getValue(receipt: Receipt): String =
-        receipt.trip.getFormattedStartDate(
-            localizedContext,
-            preferences.get(UserPreference.General.DateSeparator)
-        )
+    override fun getValue(rowItem: Receipt): String {
+        val trip = rowItem.trip
+        return dateFormatter.getFormattedDate(trip.startDate, trip.startTimeZone)
+    }
 
 
     override fun getFooter(rows: List<Receipt>): String =

--- a/app/src/main/java/co/smartreceipts/android/model/utils/ModelUtils.java
+++ b/app/src/main/java/co/smartreceipts/android/model/utils/ModelUtils.java
@@ -30,6 +30,7 @@ public class ModelUtils {
         throw new RuntimeException("This class uses static calls only. It cannot be instantiated");
     }
 
+    @NonNull
     public static String getFormattedDate(@NonNull java.util.Date date, @NonNull TimeZone timeZone, @NonNull Context context, @NonNull String separator) {
         return getFormattedDate(new Date(date.getTime()), timeZone, context, separator);
     }
@@ -44,6 +45,7 @@ public class ModelUtils {
      * @param separator - the date separator (e.g. "/", "-", ".")
      * @return the formatted date string for the start date
      */
+    @NonNull
     public static String getFormattedDate(@NonNull Date date, @NonNull TimeZone timeZone, @NonNull Context context, @NonNull String separator) {
         final java.text.DateFormat format = android.text.format.DateFormat.getDateFormat(context);
         format.setTimeZone(timeZone); // Hack to shift the timezone appropriately
@@ -58,6 +60,7 @@ public class ModelUtils {
      * @param number - the {@link BigDecimal} to format
      * @return the decimal formatted price {@link String}
      */
+    @NonNull
     public static String getDecimalFormattedValue(float number) {
         return getDecimalFormattedValue(BigDecimal.valueOf(number));
     }
@@ -104,6 +107,7 @@ public class ModelUtils {
      * @param currency - the {@link PriceCurrency} to use. If this is {@code null}, return {@link #getDecimalFormattedValue(BigDecimal)}
      * @return - the currency formatted price {@link String}
      */
+    @NonNull
     public static String getCurrencyFormattedValue(@NonNull BigDecimal decimal, @Nullable PriceCurrency currency) {
         return getCurrencyFormattedValue(decimal, currency, Price.DEFAULT_DECIMAL_PRECISION);
     }
@@ -116,7 +120,9 @@ public class ModelUtils {
      * @param decimalPrecision - the desired decimal precision to use (eg 2 => "$25.20", 3 => "$25.200")
      * @return - the currency formatted price {@link String}
      */
-    public static String getCurrencyFormattedValue(@NonNull BigDecimal decimal, @Nullable PriceCurrency currency,
+    @NonNull
+    public static String getCurrencyFormattedValue(@NonNull BigDecimal decimal,
+                                                   @Nullable PriceCurrency currency,
                                                    int decimalPrecision) {
         if (currency != null) {
             return currency.format(decimal, decimalPrecision);
@@ -133,6 +139,7 @@ public class ModelUtils {
      * @param currency - the {@link PriceCurrency} to use. If this is {@code null}, return {@link #getDecimalFormattedValue(BigDecimal)}
      * @return - the currency formatted price {@link String}
      */
+    @NonNull
     public static String getCurrencyCodeFormattedValue(@NonNull BigDecimal decimal, @Nullable PriceCurrency currency) {
         return getCurrencyCodeFormattedValue(decimal, currency, Price.DEFAULT_DECIMAL_PRECISION);
     }
@@ -145,7 +152,9 @@ public class ModelUtils {
      * @param decimalPrecision - the desired decimal precision to use (eg 2 => "USD25.20", 3 => "USD25.200")
      * @return - the currency formatted price {@link String}
      */
-    public static String getCurrencyCodeFormattedValue(@NonNull BigDecimal decimal, @Nullable PriceCurrency currency,
+    @NonNull
+    public static String getCurrencyCodeFormattedValue(@NonNull BigDecimal decimal,
+                                                       @Nullable PriceCurrency currency,
                                                        int decimalPrecision) {
         final StringBuilder stringBuilder = new StringBuilder();
         if (currency != null) {

--- a/app/src/main/java/co/smartreceipts/android/receipts/ReceiptsAdapter.java
+++ b/app/src/main/java/co/smartreceipts/android/receipts/ReceiptsAdapter.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 
 import co.smartreceipts.android.R;
 import co.smartreceipts.android.activities.NavigationHandler;
+import co.smartreceipts.android.date.DateFormatter;
 import co.smartreceipts.android.model.Receipt;
 import co.smartreceipts.android.receipts.ordering.ReceiptsOrderer;
 import co.smartreceipts.android.settings.UserPreferenceManager;
@@ -46,6 +47,7 @@ public class ReceiptsAdapter extends DraggableCardsAdapter<Receipt> implements R
 
     private final Context context;
     private final UserPreferenceManager preferences;
+    private final DateFormatter dateFormatter;
     private final BackupProvidersManager backupProvidersManager;
     private final NavigationHandler navigationHandler;
     private final ReceiptsOrderer receiptsOrderer;
@@ -63,12 +65,14 @@ public class ReceiptsAdapter extends DraggableCardsAdapter<Receipt> implements R
 
     public ReceiptsAdapter(@NonNull Context context,
                            @NonNull UserPreferenceManager preferenceManager,
+                           @NonNull DateFormatter dateFormatter,
                            @NonNull BackupProvidersManager backupProvidersManager,
                            @NonNull NavigationHandler navigationHandler,
                            @NonNull ReceiptsOrderer receiptsOrderer,
                            @NonNull Picasso picasso) {
-        this.preferences = Preconditions.checkNotNull(preferenceManager);
         this.context = Preconditions.checkNotNull(context);
+        this.preferences = Preconditions.checkNotNull(preferenceManager);
+        this.dateFormatter = Preconditions.checkNotNull(dateFormatter);
         this.backupProvidersManager = Preconditions.checkNotNull(backupProvidersManager);
         this.navigationHandler = Preconditions.checkNotNull(navigationHandler);
         this.receiptsOrderer = Preconditions.checkNotNull(receiptsOrderer);
@@ -193,17 +197,15 @@ public class ReceiptsAdapter extends DraggableCardsAdapter<Receipt> implements R
         Receipt previousReceipt = null;
 
         for (Receipt receipt : items) {
+            final String receiptDate = dateFormatter.getFormattedDate(receipt.getDate(), receipt.getTimeZone());
             if (previousReceipt != null) {
-                final String receiptDate = receipt.getFormattedDate(context, preferences.get(UserPreference.General.DateSeparator));
-                final String previousReceiptDate = previousReceipt.getFormattedDate(context, preferences.get(UserPreference.General.DateSeparator));
+                final String previousReceiptDate = dateFormatter.getFormattedDate(previousReceipt.getDate(), previousReceipt.getTimeZone());
 
                 if (!receiptDate.equals(previousReceiptDate)) {
-                    listItems.add(new ReceiptHeaderItem(receipt.getDate().getTime(),
-                            receipt.getFormattedDate(context, preferences.get(UserPreference.General.DateSeparator))));
+                    listItems.add(new ReceiptHeaderItem(receipt.getDate().getTime(), receiptDate));
                 }
             } else {
-                listItems.add(new ReceiptHeaderItem(receipt.getDate().getTime(),
-                        receipt.getFormattedDate(context, preferences.get(UserPreference.General.DateSeparator))));
+                listItems.add(new ReceiptHeaderItem(receipt.getDate().getTime(), receiptDate));
             }
 
             listItems.add(new ReceiptContentItem(receipt));

--- a/app/src/main/java/co/smartreceipts/android/receipts/ReceiptsListFragment.java
+++ b/app/src/main/java/co/smartreceipts/android/receipts/ReceiptsListFragment.java
@@ -39,6 +39,7 @@ import co.smartreceipts.android.activities.NavigationHandler;
 import co.smartreceipts.android.analytics.Analytics;
 import co.smartreceipts.android.analytics.events.Events;
 import co.smartreceipts.android.config.ConfigurationManager;
+import co.smartreceipts.android.date.DateFormatter;
 import co.smartreceipts.android.fragments.ImportPhotoPdfDialogFragment;
 import co.smartreceipts.android.fragments.ReceiptMoveCopyDialogFragment;
 import co.smartreceipts.android.fragments.ReportInfoFragment;
@@ -147,13 +148,10 @@ public class ReceiptsListFragment extends ReceiptsFragment implements ReceiptTab
     UserPreferenceManager preferenceManager;
 
     @Inject
-    OrderingPreferencesManager orderingPreferencesManager;
+    DateFormatter dateFormatter;
 
     @Inject
     ReceiptsOrderer receiptsOrderer;
-
-    @Inject
-    ReceiptAttachmentManager receiptAttachmentManager;
 
     @Inject
     Picasso picasso;
@@ -207,7 +205,7 @@ public class ReceiptsListFragment extends ReceiptsFragment implements ReceiptTab
     public void onCreate(Bundle savedInstanceState) {
         Logger.debug(this, "onCreate");
         super.onCreate(savedInstanceState);
-        adapter = new ReceiptsAdapter(getContext(), preferenceManager, backupProvidersManager, navigationHandler, receiptsOrderer, picasso);
+        adapter = new ReceiptsAdapter(getContext(), preferenceManager, dateFormatter, backupProvidersManager, navigationHandler, receiptsOrderer, picasso);
         if (savedInstanceState != null) {
             imageUri = savedInstanceState.getParcelable(OUT_IMAGE_URI);
             highlightedReceipt = savedInstanceState.getParcelable(OUT_HIGHLIGHTED_RECEIPT);

--- a/app/src/main/java/co/smartreceipts/android/workers/reports/AbstractReport.java
+++ b/app/src/main/java/co/smartreceipts/android/workers/reports/AbstractReport.java
@@ -4,6 +4,7 @@ import android.support.annotation.NonNull;
 
 import com.google.common.base.Preconditions;
 
+import co.smartreceipts.android.date.DateFormatter;
 import co.smartreceipts.android.persistence.DatabaseHelper;
 import co.smartreceipts.android.persistence.PersistenceManager;
 import co.smartreceipts.android.settings.UserPreferenceManager;
@@ -18,20 +19,25 @@ public abstract class AbstractReport implements Report {
     private final DatabaseHelper databaseHelper;
     private final UserPreferenceManager userPreferenceManager;
     private final StorageManager storageManager;
+    private final DateFormatter dateFormatter;
 
     protected AbstractReport(@NonNull ReportResourcesManager reportResourcesManager,
-                             @NonNull PersistenceManager persistenceManager) {
+                             @NonNull PersistenceManager persistenceManager,
+                             @NonNull DateFormatter dateFormatter) {
         this(reportResourcesManager, persistenceManager.getDatabase(),
-                persistenceManager.getPreferenceManager(), persistenceManager.getStorageManager());
+                persistenceManager.getPreferenceManager(), persistenceManager.getStorageManager(), dateFormatter);
     }
 
     protected AbstractReport(@NonNull ReportResourcesManager reportResourcesManager,
-                             @NonNull DatabaseHelper db, @NonNull UserPreferenceManager preferences,
-                             @NonNull StorageManager storageManager) {
+                             @NonNull DatabaseHelper db,
+                             @NonNull UserPreferenceManager preferences,
+                             @NonNull StorageManager storageManager,
+                             @NonNull DateFormatter dateFormatter) {
         this.reportResourcesManager = Preconditions.checkNotNull(reportResourcesManager);
         this.databaseHelper = Preconditions.checkNotNull(db);
         this.userPreferenceManager = Preconditions.checkNotNull(preferences);
         this.storageManager = Preconditions.checkNotNull(storageManager);
+        this.dateFormatter = Preconditions.checkNotNull(dateFormatter);
     }
 
     @NonNull
@@ -52,5 +58,10 @@ public abstract class AbstractReport implements Report {
     @NonNull
     protected final StorageManager getStorageManager() {
         return storageManager;
+    }
+
+    @NonNull
+    protected final DateFormatter getDateFormatter() {
+        return dateFormatter;
     }
 }

--- a/app/src/main/java/co/smartreceipts/android/workers/reports/pdf/PdfBoxAbstractReport.java
+++ b/app/src/main/java/co/smartreceipts/android/workers/reports/pdf/PdfBoxAbstractReport.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
+import co.smartreceipts.android.date.DateFormatter;
 import co.smartreceipts.android.model.Trip;
 import co.smartreceipts.android.persistence.DatabaseHelper;
 import co.smartreceipts.android.persistence.PersistenceManager;
@@ -20,15 +21,17 @@ import wb.android.storage.StorageManager;
 public abstract class PdfBoxAbstractReport extends AbstractReport {
 
     public PdfBoxAbstractReport(@NonNull ReportResourcesManager reportResourcesManager,
-                                @NonNull PersistenceManager persistenceManager) {
-        super(reportResourcesManager, persistenceManager);
+                                @NonNull PersistenceManager persistenceManager,
+                                @NonNull DateFormatter dateFormatter) {
+        super(reportResourcesManager, persistenceManager, dateFormatter);
     }
 
     public PdfBoxAbstractReport(@NonNull ReportResourcesManager reportResourcesManager,
                                 @NonNull DatabaseHelper db,
                                 @NonNull UserPreferenceManager preferences,
-                                @NonNull StorageManager storageManager) {
-        super(reportResourcesManager, db, preferences, storageManager);
+                                @NonNull StorageManager storageManager,
+                                @NonNull DateFormatter dateFormatter) {
+        super(reportResourcesManager, db, preferences, storageManager, dateFormatter);
     }
 
     @NonNull
@@ -42,7 +45,7 @@ public abstract class PdfBoxAbstractReport extends AbstractReport {
 
             pdfStream = getStorageManager().getFOS(trip.getDirectory(), outputFileName);
 
-            PdfBoxReportFile pdfBoxReportFile = new PdfBoxReportFile(getReportResourcesManager(), getPreferences());
+            PdfBoxReportFile pdfBoxReportFile = new PdfBoxReportFile(getReportResourcesManager(), getPreferences(), getDateFormatter());
 
             createSections(trip, pdfBoxReportFile);
 

--- a/app/src/main/java/co/smartreceipts/android/workers/reports/pdf/PdfBoxFullPdfReport.java
+++ b/app/src/main/java/co/smartreceipts/android/workers/reports/pdf/PdfBoxFullPdfReport.java
@@ -5,6 +5,7 @@ import android.support.annotation.NonNull;
 import java.util.ArrayList;
 import java.util.List;
 
+import co.smartreceipts.android.date.DateFormatter;
 import co.smartreceipts.android.model.Column;
 import co.smartreceipts.android.model.ColumnDefinitions;
 import co.smartreceipts.android.model.Distance;
@@ -27,10 +28,13 @@ public class PdfBoxFullPdfReport extends PdfBoxAbstractReport {
     private final GroupingController groupingController;
     private final PurchaseWallet purchaseWallet;
 
-    public PdfBoxFullPdfReport(ReportResourcesManager reportResourcesManager, DatabaseHelper db,
+    public PdfBoxFullPdfReport(ReportResourcesManager reportResourcesManager,
+                               DatabaseHelper db,
                                UserPreferenceManager preferences,
-                               StorageManager storageManager, PurchaseWallet purchaseWallet) {
-        super(reportResourcesManager, db, preferences, storageManager);
+                               StorageManager storageManager,
+                               PurchaseWallet purchaseWallet,
+                               DateFormatter dateFormatter) {
+        super(reportResourcesManager, db, preferences, storageManager, dateFormatter);
         this.groupingController = new GroupingController(db, reportResourcesManager.getLocalizedContext(), preferences);
         this.purchaseWallet = purchaseWallet;
     }

--- a/app/src/main/java/co/smartreceipts/android/workers/reports/pdf/PdfBoxImagesOnlyReport.java
+++ b/app/src/main/java/co/smartreceipts/android/workers/reports/pdf/PdfBoxImagesOnlyReport.java
@@ -5,6 +5,7 @@ import android.support.annotation.NonNull;
 import java.util.ArrayList;
 import java.util.List;
 
+import co.smartreceipts.android.date.DateFormatter;
 import co.smartreceipts.android.model.Receipt;
 import co.smartreceipts.android.model.Trip;
 import co.smartreceipts.android.persistence.DatabaseHelper;
@@ -17,14 +18,17 @@ import wb.android.storage.StorageManager;
 public class PdfBoxImagesOnlyReport extends PdfBoxAbstractReport {
 
     public PdfBoxImagesOnlyReport(@NonNull ReportResourcesManager reportResourcesManager,
-                                  @NonNull PersistenceManager persistenceManager) {
-        super(reportResourcesManager, persistenceManager);
+                                  @NonNull PersistenceManager persistenceManager,
+                                  DateFormatter dateFormatter) {
+        super(reportResourcesManager, persistenceManager, dateFormatter);
     }
 
     public PdfBoxImagesOnlyReport(@NonNull ReportResourcesManager reportResourcesManager,
-                                  @NonNull DatabaseHelper db, @NonNull UserPreferenceManager preferences,
-                                  @NonNull StorageManager storageManager) {
-        super(reportResourcesManager, db, preferences, storageManager);
+                                  @NonNull DatabaseHelper db,
+                                  @NonNull UserPreferenceManager preferences,
+                                  @NonNull StorageManager storageManager,
+                                  DateFormatter dateFormatter) {
+        super(reportResourcesManager, db, preferences, storageManager, dateFormatter);
     }
 
     @Override

--- a/app/src/main/java/co/smartreceipts/android/workers/reports/pdf/pdfbox/DefaultPdfBoxContext.java
+++ b/app/src/main/java/co/smartreceipts/android/workers/reports/pdf/pdfbox/DefaultPdfBoxContext.java
@@ -8,6 +8,7 @@ import com.google.common.base.Preconditions;
 import com.tom_roush.pdfbox.pdmodel.common.PDRectangle;
 
 import co.smartreceipts.android.R;
+import co.smartreceipts.android.date.DateFormatter;
 import co.smartreceipts.android.settings.UserPreferenceManager;
 import co.smartreceipts.android.settings.catalog.UserPreference;
 import co.smartreceipts.android.workers.reports.pdf.colors.PdfColorManager;
@@ -19,17 +20,20 @@ public class DefaultPdfBoxContext implements PdfBoxContext {
     private final PdfFontManager fontManager;
     private final PdfColorManager colorManager;
     private final UserPreferenceManager preferences;
+    private final DateFormatter dateFormatter;
 
     private PDRectangle pageSize;
 
     public DefaultPdfBoxContext(@NonNull Context localizedContext,
                                 @NonNull PdfFontManager fontManager,
                                 @NonNull PdfColorManager colorManager,
-                                @NonNull UserPreferenceManager preferences) {
+                                @NonNull UserPreferenceManager preferences,
+                                @NonNull DateFormatter dateFormatter) {
         this.localizedContext = Preconditions.checkNotNull(localizedContext);
         this.fontManager = Preconditions.checkNotNull(fontManager);
         this.colorManager = Preconditions.checkNotNull(colorManager);
         this.preferences = Preconditions.checkNotNull(preferences);
+        this.dateFormatter = Preconditions.checkNotNull(dateFormatter);
 
         if (preferences.get(UserPreference.ReportOutput.DefaultPdfPageSize).equals(localizedContext.getString(R.string.pref_output_pdf_page_size_letter_entryValue))) {
             pageSize = PDRectangle.LETTER;
@@ -75,6 +79,12 @@ public class DefaultPdfBoxContext implements PdfBoxContext {
     @Override
     public UserPreferenceManager getPreferences() {
         return preferences;
+    }
+
+    @NonNull
+    @Override
+    public DateFormatter getDateFormatter() {
+        return dateFormatter;
     }
 
     @NonNull

--- a/app/src/main/java/co/smartreceipts/android/workers/reports/pdf/pdfbox/PdfBoxContext.java
+++ b/app/src/main/java/co/smartreceipts/android/workers/reports/pdf/pdfbox/PdfBoxContext.java
@@ -7,6 +7,7 @@ import android.support.annotation.StringRes;
 
 import com.tom_roush.pdfbox.pdmodel.common.PDRectangle;
 
+import co.smartreceipts.android.date.DateFormatter;
 import co.smartreceipts.android.settings.UserPreferenceManager;
 import co.smartreceipts.android.workers.reports.pdf.colors.PdfColorManager;
 import co.smartreceipts.android.workers.reports.pdf.fonts.PdfFontManager;
@@ -32,6 +33,9 @@ public interface PdfBoxContext {
 
     @NonNull
     UserPreferenceManager getPreferences();
+
+    @NonNull
+    DateFormatter getDateFormatter();
 
     @NonNull
     PdfFontManager getFontManager();

--- a/app/src/main/java/co/smartreceipts/android/workers/reports/pdf/pdfbox/PdfBoxReportFile.java
+++ b/app/src/main/java/co/smartreceipts/android/workers/reports/pdf/pdfbox/PdfBoxReportFile.java
@@ -10,6 +10,7 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import co.smartreceipts.android.date.DateFormatter;
 import co.smartreceipts.android.model.Column;
 import co.smartreceipts.android.model.Distance;
 import co.smartreceipts.android.model.Receipt;
@@ -33,7 +34,8 @@ public class PdfBoxReportFile implements PdfReportFile, PdfBoxSectionFactory {
 
 
     public PdfBoxReportFile(@NonNull ReportResourcesManager reportResourcesManager,
-                            @NonNull UserPreferenceManager preferences) throws IOException {
+                            @NonNull UserPreferenceManager preferences,
+                            @NonNull DateFormatter dateFormatter) throws IOException {
 
         this.reportResourcesManager = Preconditions.checkNotNull(reportResourcesManager);
 
@@ -45,7 +47,7 @@ public class PdfBoxReportFile implements PdfReportFile, PdfBoxSectionFactory {
         fontManager.initialize();
 
         pdfBoxContext = new DefaultPdfBoxContext(reportResourcesManager.getLocalizedContext(),
-                fontManager, colorManager, preferences);
+                fontManager, colorManager, preferences, dateFormatter);
     }
 
 

--- a/app/src/main/java/co/smartreceipts/android/workers/reports/pdf/renderer/impl/GridReceiptsRendererFactory.java
+++ b/app/src/main/java/co/smartreceipts/android/workers/reports/pdf/renderer/impl/GridReceiptsRendererFactory.java
@@ -10,6 +10,7 @@ import com.tom_roush.pdfbox.util.awt.AWTColor;
 import java.util.ArrayList;
 import java.util.List;
 
+import co.smartreceipts.android.date.DateFormatter;
 import co.smartreceipts.android.model.Receipt;
 import co.smartreceipts.android.settings.UserPreferenceManager;
 import co.smartreceipts.android.utils.log.Logger;
@@ -31,22 +32,31 @@ public class GridReceiptsRendererFactory {
 
     private final Context context;
     private final UserPreferenceManager userPreferenceManager;
+    private final DateFormatter dateFormatter;
     private final PDDocument pdDocument;
     private final PdfBoxPageDecorations decorations;
     private final List<Receipt> receipts = new ArrayList<>();
     private final int columns;
     private final int rows;
 
-    public GridReceiptsRendererFactory(@NonNull Context context, @NonNull UserPreferenceManager userPreferenceManager,
-                                       @NonNull PDDocument pdDocument, @NonNull PdfBoxPageDecorations decorations) {
-        this(context, userPreferenceManager, pdDocument, decorations, DEFAULT_NUMBER_COLUMNS, DEFAULT_NUMBER_ROWS);
+    public GridReceiptsRendererFactory(@NonNull Context context,
+                                       @NonNull UserPreferenceManager userPreferenceManager,
+                                       @NonNull DateFormatter dateFormatter,
+                                       @NonNull PDDocument pdDocument,
+                                       @NonNull PdfBoxPageDecorations decorations) {
+        this(context, userPreferenceManager, dateFormatter, pdDocument, decorations, DEFAULT_NUMBER_COLUMNS, DEFAULT_NUMBER_ROWS);
     }
 
-    public GridReceiptsRendererFactory(@NonNull Context context, @NonNull UserPreferenceManager userPreferenceManager,
-                                       @NonNull PDDocument pdDocument, @NonNull PdfBoxPageDecorations decorations,
-                                       int columns, int rows) {
+    public GridReceiptsRendererFactory(@NonNull Context context,
+                                       @NonNull UserPreferenceManager userPreferenceManager,
+                                       @NonNull DateFormatter dateFormatter,
+                                       @NonNull PDDocument pdDocument,
+                                       @NonNull PdfBoxPageDecorations decorations,
+                                       int columns,
+                                       int rows) {
         this.context = Preconditions.checkNotNull(context.getApplicationContext());
         this.userPreferenceManager = Preconditions.checkNotNull(userPreferenceManager);
+        this.dateFormatter = Preconditions.checkNotNull(dateFormatter);
         this.pdDocument = Preconditions.checkNotNull(pdDocument);
         this.decorations = Preconditions.checkNotNull(decorations);
         this.columns = columns;
@@ -81,7 +91,7 @@ public class GridReceiptsRendererFactory {
                     final Receipt receipt = receipts.get(index);
                     Preconditions.checkNotNull(receipt.getFile(), "All receipts must have an image file");
 
-                    labelRows.add(new ReceiptLabelTextRenderer(receipt, context, pdDocument, userPreferenceManager, color, fontSpec));
+                    labelRows.add(new ReceiptLabelTextRenderer(receipt, context, pdDocument, userPreferenceManager, dateFormatter, color, fontSpec));
                     if (receipt.hasImage()) {
                         imageRows.add(new PDImageXRenderer(new ImagePDImageXFactory(context, pdDocument, receipt.getFile())));
                     } else {

--- a/app/src/main/java/co/smartreceipts/android/workers/reports/pdf/renderer/impl/ReceiptLabelTextRenderer.java
+++ b/app/src/main/java/co/smartreceipts/android/workers/reports/pdf/renderer/impl/ReceiptLabelTextRenderer.java
@@ -9,6 +9,7 @@ import com.google.common.base.Preconditions;
 import com.tom_roush.pdfbox.pdmodel.PDDocument;
 import com.tom_roush.pdfbox.util.awt.AWTColor;
 
+import co.smartreceipts.android.date.DateFormatter;
 import co.smartreceipts.android.model.Receipt;
 import co.smartreceipts.android.settings.UserPreferenceManager;
 import co.smartreceipts.android.settings.catalog.UserPreference;
@@ -18,9 +19,14 @@ import co.smartreceipts.android.workers.reports.pdf.renderer.text.TextRenderer;
 public class ReceiptLabelTextRenderer extends TextRenderer {
 
 
-    public ReceiptLabelTextRenderer(@NonNull Receipt receipt, @NonNull Context context, @NonNull PDDocument pdDocument,
-                                    @NonNull UserPreferenceManager userPreferenceManager, @NonNull AWTColor color, @NonNull PdfFontSpec fontSpec) {
-        super(context, pdDocument, new TextFormatter(context, userPreferenceManager).buildLegendForImage(receipt), color, fontSpec);
+    public ReceiptLabelTextRenderer(@NonNull Receipt receipt,
+                                    @NonNull Context context,
+                                    @NonNull PDDocument pdDocument,
+                                    @NonNull UserPreferenceManager userPreferenceManager,
+                                    @NonNull DateFormatter dateFormatter,
+                                    @NonNull AWTColor color,
+                                    @NonNull PdfFontSpec fontSpec) {
+        super(context, pdDocument, new TextFormatter(userPreferenceManager, dateFormatter).buildLegendForImage(receipt), color, fontSpec);
     }
 
     @VisibleForTesting
@@ -28,12 +34,13 @@ public class ReceiptLabelTextRenderer extends TextRenderer {
 
         private static final String SEP = " \u2022 ";
 
-        private final Context context;
         private final UserPreferenceManager userPreferenceManager;
+        private final DateFormatter dateFormatter;
 
-        public TextFormatter(@NonNull Context context, @NonNull UserPreferenceManager userPreferenceManager) {
-            this.context = Preconditions.checkNotNull(context.getApplicationContext());
+        public TextFormatter(@NonNull UserPreferenceManager userPreferenceManager,
+                             @NonNull DateFormatter dateFormatter) {
             this.userPreferenceManager = Preconditions.checkNotNull(userPreferenceManager);
+            this.dateFormatter = Preconditions.checkNotNull(dateFormatter);
         }
 
         @NonNull
@@ -47,8 +54,7 @@ public class ReceiptLabelTextRenderer extends TextRenderer {
                     : "";
 
             return num + SEP + receipt.getName() + SEP
-                    + receipt.getFormattedDate(context,
-                    userPreferenceManager.get(UserPreference.General.DateSeparator)) + extra;
+                    + dateFormatter.getFormattedDate(receipt.getDate(), receipt.getTimeZone()) + extra;
         }
     }
 }

--- a/app/src/test/java/co/smartreceipts/android/persistence/database/tables/CSVTableTest.java
+++ b/app/src/test/java/co/smartreceipts/android/persistence/database/tables/CSVTableTest.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
+import co.smartreceipts.android.date.DateFormatter;
 import co.smartreceipts.android.model.Column;
 import co.smartreceipts.android.model.Receipt;
 import co.smartreceipts.android.model.impl.columns.receipts.ReceiptCategoryNameColumn;
@@ -56,6 +57,9 @@ public class CSVTableTest {
     UserPreferenceManager preferences;
 
     @Mock
+    DateFormatter dateFormatter;
+
+    @Mock
     SQLiteDatabase database;
 
     @Mock
@@ -77,7 +81,7 @@ public class CSVTableTest {
         MockitoAnnotations.initMocks(this);
 
         sqliteOpenHelper = new TestSQLiteOpenHelper(RuntimeEnvironment.application);
-        final ReceiptColumnDefinitions receiptColumnDefinitions = new ReceiptColumnDefinitions(reportResourcesManager, preferences);
+        final ReceiptColumnDefinitions receiptColumnDefinitions = new ReceiptColumnDefinitions(reportResourcesManager, preferences, dateFormatter);
         csvTable = new CSVTable(sqliteOpenHelper, receiptColumnDefinitions, orderingPreferencesManager);
 
         // Now create the table and insert some defaults

--- a/app/src/test/java/co/smartreceipts/android/persistence/database/tables/PDFTableTest.java
+++ b/app/src/test/java/co/smartreceipts/android/persistence/database/tables/PDFTableTest.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
+import co.smartreceipts.android.date.DateFormatter;
 import co.smartreceipts.android.model.Column;
 import co.smartreceipts.android.model.Receipt;
 import co.smartreceipts.android.model.impl.columns.receipts.ReceiptCategoryNameColumn;
@@ -56,6 +57,9 @@ public class PDFTableTest {
     UserPreferenceManager preferences;
 
     @Mock
+    DateFormatter dateFormatter;
+
+    @Mock
     SQLiteDatabase sqliteDatabase;
 
     @Mock
@@ -77,7 +81,7 @@ public class PDFTableTest {
         MockitoAnnotations.initMocks(this);
 
         sqliteOpenHelper = new TestSQLiteOpenHelper(RuntimeEnvironment.application);
-        final ReceiptColumnDefinitions receiptColumnDefinitions = new ReceiptColumnDefinitions(reportResourcesManager, preferences);
+        final ReceiptColumnDefinitions receiptColumnDefinitions = new ReceiptColumnDefinitions(reportResourcesManager, preferences, dateFormatter);
         pdfTable = new PDFTable(sqliteOpenHelper, receiptColumnDefinitions, orderingPreferencesManager);
 
         // Now create the table and insert some defaults

--- a/app/src/test/java/co/smartreceipts/android/persistence/database/tables/adapters/ColumnDatabaseAdapterTest.java
+++ b/app/src/test/java/co/smartreceipts/android/persistence/database/tables/adapters/ColumnDatabaseAdapterTest.java
@@ -13,6 +13,7 @@ import org.robolectric.RuntimeEnvironment;
 
 import java.util.UUID;
 
+import co.smartreceipts.android.date.DateFormatter;
 import co.smartreceipts.android.model.Column;
 import co.smartreceipts.android.model.Receipt;
 import co.smartreceipts.android.model.impl.columns.receipts.ReceiptColumnDefinitions;
@@ -55,6 +56,9 @@ public class ColumnDatabaseAdapterTest {
     UserPreferenceManager preferences;
 
     @Mock
+    DateFormatter dateFormatter;
+
+    @Mock
     SyncStateAdapter syncStateAdapter;
 
     @Mock
@@ -72,7 +76,7 @@ public class ColumnDatabaseAdapterTest {
         final int uuidIndex = 4;
 
         receiptNameColumn = new ReceiptNameColumn(ID, getSyncState, CUSTOM_ORDER_ID, COLUMN_UUID);
-        ReceiptColumnDefinitions receiptColumnDefinitions = new ReceiptColumnDefinitions(reportResourcesManager, preferences);
+        ReceiptColumnDefinitions receiptColumnDefinitions = new ReceiptColumnDefinitions(reportResourcesManager, preferences, dateFormatter);
 
         when(reportResourcesManager.getLocalizedContext()).thenReturn(RuntimeEnvironment.systemContext);
 

--- a/app/src/test/java/co/smartreceipts/android/report/InteractivePdfBoxTest.java
+++ b/app/src/test/java/co/smartreceipts/android/report/InteractivePdfBoxTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.UUID;
 
 import co.smartreceipts.android.TestResourceReader;
+import co.smartreceipts.android.date.DateFormatter;
 import co.smartreceipts.android.model.Column;
 import co.smartreceipts.android.model.Distance;
 import co.smartreceipts.android.model.Receipt;
@@ -104,6 +105,8 @@ public class InteractivePdfBoxTest {
     @Mock
     ReportResourcesManager reportResourcesManager;
 
+    DateFormatter dateFormatter;
+
     /**
      * Base method, to be overridden by subclasses. The subclass must annotate the method
      * with the JUnit <code>@Before</code> annotation, and initialize the mocks.
@@ -114,6 +117,7 @@ public class InteractivePdfBoxTest {
 
         context = RuntimeEnvironment.application;
         testResourceReader = new TestResourceReader();
+        dateFormatter = new DateFormatter(context, userPreferenceManager);
 
         when(persistenceManager.getPreferenceManager()).thenReturn(userPreferenceManager);
 
@@ -479,12 +483,12 @@ public class InteractivePdfBoxTest {
     }
 
     private void writeFullReport(@NonNull Trip trip, @NonNull List<Receipt> receipts) throws Exception {
-        final PdfBoxReportFile pdfBoxReportFile = new PdfBoxReportFile(reportResourcesManager, userPreferenceManager);
+        final PdfBoxReportFile pdfBoxReportFile = new PdfBoxReportFile(reportResourcesManager, userPreferenceManager, dateFormatter);
 
         final ArrayList<Column<Receipt>> receiptColumns = new ArrayList<>();
         receiptColumns.add(new ReceiptNameColumn(1, new DefaultSyncState(), 0, UUID.randomUUID()));
         receiptColumns.add(new ReceiptPriceColumn(2, new DefaultSyncState(), 0, UUID.randomUUID()));
-        receiptColumns.add(new ReceiptDateColumn(3, new DefaultSyncState(), context, userPreferenceManager, 0, UUID.randomUUID()));
+        receiptColumns.add(new ReceiptDateColumn(3, new DefaultSyncState(), dateFormatter, 0, UUID.randomUUID()));
         receiptColumns.add(new ReceiptCategoryNameColumn(4, new DefaultSyncState(), 0, UUID.randomUUID()));
 
         final List<Column<Distance>> distanceColumns = new ArrayList<>();
@@ -519,7 +523,7 @@ public class InteractivePdfBoxTest {
     }
 
     private void writeImagesOnlyReport(@NonNull Trip trip, @NonNull List<Receipt> receipts) throws Exception {
-        final PdfBoxReportFile pdfBoxReportFile = new PdfBoxReportFile(reportResourcesManager, userPreferenceManager);
+        final PdfBoxReportFile pdfBoxReportFile = new PdfBoxReportFile(reportResourcesManager, userPreferenceManager, dateFormatter);
         pdfBoxReportFile.addSection(pdfBoxReportFile.createReceiptsImagesSection(trip, receipts));
 
         OutputStream outputStream = null;


### PR DESCRIPTION
Previously each model would wrap the date formatting internally, but this introduces challenges around adding future settings to the dates. As a result, we're moving the date formatter to exist as a dedicated object. A series of upcoming commits will improve how we control and use this.