### PR TITLE
Added a setting to customize how the date formats appear

### DIFF
--- a/app/src/main/java/co/smartreceipts/android/SmartReceiptsApplication.java
+++ b/app/src/main/java/co/smartreceipts/android/SmartReceiptsApplication.java
@@ -239,6 +239,7 @@ public class SmartReceiptsApplication extends Application implements HasActivity
         flex.initialize();
         userPreferenceManager.initialize();
         orderingPreferencesManager.initialize();
+        dateFormatter.initialize();
         onLaunchDataPreFetcher.loadUserData();
         identityManager.initialize();
         pushManager.initialize();
@@ -247,8 +248,8 @@ public class SmartReceiptsApplication extends Application implements HasActivity
         ocrManager.initialize();
         crashReporter.initialize();
         receiptsOrderer.initialize();
-        markedForDeletionCleaner.safelyDeleteAllOutstandingItems();
         picassoInitializer.initialize();
+        markedForDeletionCleaner.safelyDeleteAllOutstandingItems();
         memoryLeakMonitor.initialize();
 
         PDFBoxResourceLoader.init(getApplicationContext());

--- a/app/src/main/java/co/smartreceipts/android/date/DateFormatter.kt
+++ b/app/src/main/java/co/smartreceipts/android/date/DateFormatter.kt
@@ -1,14 +1,22 @@
 package co.smartreceipts.android.date
 
+import android.annotation.SuppressLint
 import android.content.Context
+import android.support.annotation.StringRes
+import co.smartreceipts.android.R
 import co.smartreceipts.android.di.scopes.ApplicationScope
 import co.smartreceipts.android.settings.UserPreferenceManager
 import co.smartreceipts.android.settings.catalog.UserPreference
+import co.smartreceipts.android.utils.log.Logger
+import co.smartreceipts.android.utils.rx.RxSchedulers
+import io.reactivex.Scheduler
 import java.sql.Date
+import java.text.DateFormat
+import java.text.SimpleDateFormat
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
-import kotlin.collections.HashMap
+import javax.inject.Named
 
 
 /**
@@ -17,9 +25,98 @@ import kotlin.collections.HashMap
  */
 @ApplicationScope
 class DateFormatter @Inject constructor(private val context: Context,
-                                        private val userPreferenceManager: UserPreferenceManager) {
+                                        private val userPreferenceManager: UserPreferenceManager,
+                                        @Named(RxSchedulers.IO) private val scheduler: Scheduler) {
 
-    private val threadLocalCache = ConcurrentHashMap<DateFormatMetadata, DateFormatThreadLocal>()
+    @Suppress("EnumEntryName")
+    enum class DateFormatOption(@StringRes val stringResId: Int) {
+        /**
+         * The default format option for Android, which is [java.text.DateFormat.SHORT]. This
+         * formats dates according to the phone's default set of preferences.
+         */
+        Default(R.string.pref_general_date_format_default_entryValue),
+
+        /**
+         * The default American style of date, which appears like "MM/DD/YYYY"
+         *
+         * When using this, we would expect:
+         *  - "December 26, 2018" to appear as "12/26/2018"
+         *  - "January 3, 2019" to appear as "1/3/2019"
+         */
+        M_d_yyyy(R.string.pref_general_date_format_M_d_yyyy_entryValue),
+
+        /**
+         * The default European style of date, which appears like "DD/MM/YYYY"
+         *
+         * When using this, we would expect:
+         *  - "December 26, 2018" to appear as "26/12/2018"
+         *  - "January 3, 2019" to appear as "3/1/2019"
+         */
+        d_M_yyyy(R.string.pref_general_date_format_d_M_yyyy_entryValue),
+
+        /**
+         * A date format, which appears like "YYYY/MM/DD"
+         *
+         * When using this, we would expect:
+         *  - "December 26, 2018" to appear as "2018/12/26"
+         *  - "January 3, 2019" to appear as "2019/01/03"
+         */
+        yyyy_MM_dd(R.string.pref_general_date_format_yyyy_MM_dd_entryValue);
+
+    }
+
+    private val threadLocalCache = ConcurrentHashMap<TimeZone, DateFormatThreadLocal>()
+
+    private var separator = DateUtils.getDateSeparator(context)
+    private var dateFormatOption = DateFormatOption.Default
+
+    /**
+     * Initializes our date formatter, so that we properly apply all of the desired user settings
+     */
+    @SuppressLint("CheckResult")
+    fun initialize() {
+        // Pre-fetch our initial date format and separator value to avoid reading this on the UI thread
+        userPreferenceManager.getSingle(UserPreference.General.DateSeparator)
+                .subscribeOn(scheduler)
+                .subscribe { separator ->
+                    this.separator = separator
+                }
+        userPreferenceManager.getSingle(UserPreference.General.DateFormat)
+                .map { getDateFormatOption(it) }
+                .subscribeOn(scheduler)
+                .subscribe { dateFormatOption ->
+                    this.dateFormatOption = dateFormatOption
+                }
+
+        // Monitor for future changes to our date separator
+        userPreferenceManager.userPreferenceChangeStream
+                .subscribeOn(scheduler)
+                .filter { it == UserPreference.General.DateSeparator }
+                .map { userPreferenceManager[UserPreference.General.DateSeparator] }
+                .doOnNext {
+                    // Whenever we get a result, clear our cache
+                    threadLocalCache.clear()
+                    Logger.info(this, "The user changed the date separator value to {}.", it)
+                }
+                .subscribe {
+                    separator = it
+                }
+
+        // Monitor for future changes to our date format
+        userPreferenceManager.userPreferenceChangeStream
+                .subscribeOn(scheduler)
+                .filter { it == UserPreference.General.DateFormat }
+                .map { userPreferenceManager[UserPreference.General.DateFormat] }
+                .map { getDateFormatOption(it) }
+                .doOnNext {
+                    // Whenever we get a result, clear our cache
+                    threadLocalCache.clear()
+                    Logger.info(this, "The user changed the date format value to {}.", it)
+                }
+                .subscribe {
+                    dateFormatOption = it
+                }
+    }
 
     /**
      * Gets a formatted version of a date based for a particular timezone. We also apply the user's
@@ -62,26 +159,68 @@ class DateFormatter @Inject constructor(private val context: Context,
      * @return the formatted date string for the provided date
      */
     fun getFormattedDate(date: Date, timeZone: TimeZone): String {
-        // Build a set of metadata for this item to ensure that we can cache the results
-        val dateFormatMetadata = DateFormatMetadata(timeZone)
-
         // Next, leverage a ThreadLocal to fetch a thread safe handle to our date format
-        val dateFormatThreadLocal = threadLocalCache.getOrPut(dateFormatMetadata) {
-            val format = android.text.format.DateFormat.getDateFormat(context)
-            format.timeZone = timeZone // Hack to shift the timezone appropriately
-            return@getOrPut DateFormatThreadLocal(format)
+        val dateFormatThreadLocal = threadLocalCache.getOrPut(timeZone) {
+            return@getOrPut DateFormatThreadLocal(getDateFormat(dateFormatOption, timeZone))
         }
         val dateFormat = dateFormatThreadLocal.get()
-        val formattedDate = dateFormat.format(date)
-
-        // Finally, replace our date separator instance with an appropriate one
-        val separator = userPreferenceManager[UserPreference.General.DateSeparator]
-        return formattedDate.replace(DateUtils.getDateSeparator(context), separator)
+        return dateFormat.format(date)
     }
 
     /**
-     * A private data class, which we use to track metadata that could influence our date formats
+     * Gets a formatted version of a date based for a particular timezone for a specific formatting
+     * option. Please note this variant provides no caching or performance optimizations and should
+     * only be used when we require the ability to present a specific [DateFormatOption] that is
+     * NOT the user's preferred variant
+     *
+     * @param displayableDate the [DisplayableDate] to format
+     * @param dateFormatOption the [DateFormatOption] to use
+     *
+     * @return the formatted date string for the provided date
      */
-    private data class DateFormatMetadata(private val timeZone: TimeZone)
+    fun getFormattedDate(displayableDate: DisplayableDate, dateFormatOption: DateFormatOption): String {
+        return getDateFormat(dateFormatOption, displayableDate.timeZone).format(displayableDate.date)
+    }
+
+    /**
+     * Fetches one of our [DateFormatOption] values from a provider user preference [String]
+     *
+     * @param formatPreference the user preference as a [String]
+     *
+     * @return the corresponding [DateFormatOption] or [DateFormatOption.Default] if it cannot be found
+     */
+    private fun getDateFormatOption(formatPreference: String) : DateFormatOption {
+        DateFormatOption.values().forEach {
+            if (context.getString(it.stringResId) == formatPreference) {
+                return it
+            }
+        }
+        return DateFormatOption.Default
+    }
+
+    /**
+     * Gets the [DateFormat] for a particular [DateFormatOption] and [TimeZone]
+     *
+     * @param dateFormatOption the [DateFormatOption] to build this format from
+     * @param timeZone the [TimeZone] to use for this format
+     *
+     * @return the resultant [DateFormat] to use
+     */
+    private fun getDateFormat(dateFormatOption: DateFormatOption, timeZone: TimeZone) : DateFormat {
+        val formatString = when (dateFormatOption) {
+            DateFormatOption.M_d_yyyy -> "M${separator}d${separator}YYYY"
+            DateFormatOption.d_M_yyyy -> "d${separator}M${separator}YYYY"
+            DateFormatOption.yyyy_MM_dd -> "YYYY${separator}MM${separator}dd"
+            DateFormatOption.Default -> {
+                // For the default option, we get the system default and replace it's separator with the user preference
+                val systemDefaultDateFormat = android.text.format.DateFormat.getDateFormat(context) as SimpleDateFormat
+                val defaultDateSeparator = DateUtils.getDateSeparator(context)
+                systemDefaultDateFormat.toPattern().replace(defaultDateSeparator, separator)
+            }
+        }
+        val format = SimpleDateFormat(formatString, Locale.getDefault())
+        format.timeZone = timeZone // Hack to shift the timezone appropriately
+        return format
+    }
 
 }

--- a/app/src/main/java/co/smartreceipts/android/di/BaseAppModule.java
+++ b/app/src/main/java/co/smartreceipts/android/di/BaseAppModule.java
@@ -15,7 +15,8 @@ import dagger.Provides;
                     SharedPreferencesModule.class,
                     ImageLoadingModule.class,
                     ConfigurationModule.class,
-                    AutoCompleteModule.class })
+                    AutoCompleteModule.class,
+                    RxModule.class })
 public class BaseAppModule {
 
     private final SmartReceiptsApplication application;

--- a/app/src/main/java/co/smartreceipts/android/di/RxModule.kt
+++ b/app/src/main/java/co/smartreceipts/android/di/RxModule.kt
@@ -1,0 +1,35 @@
+package co.smartreceipts.android.di
+
+import co.smartreceipts.android.di.scopes.ApplicationScope
+import co.smartreceipts.android.utils.rx.RxSchedulers
+import dagger.Module
+import dagger.Provides
+import io.reactivex.Scheduler
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.schedulers.Schedulers
+import javax.inject.Named
+
+@Module
+class RxModule {
+
+    @Provides
+    @ApplicationScope
+    @Named(RxSchedulers.IO)
+    fun providesScheduler() : Scheduler {
+        return Schedulers.io()
+    }
+
+    @Provides
+    @ApplicationScope
+    @Named(RxSchedulers.COMPUTATION)
+    fun providesComputationScheduler() : Scheduler {
+        return Schedulers.computation()
+    }
+
+    @Provides
+    @ApplicationScope
+    @Named(RxSchedulers.MAIN)
+    fun providesMainThreadScheduler() : Scheduler {
+        return AndroidSchedulers.mainThread()
+    }
+}

--- a/app/src/main/java/co/smartreceipts/android/settings/catalog/UserPreference.java
+++ b/app/src/main/java/co/smartreceipts/android/settings/catalog/UserPreference.java
@@ -20,6 +20,7 @@ public final class UserPreference<T> {
         public static final UserPreference<Integer> DefaultReportDuration = new UserPreference<>(Integer.class, R.string.pref_general_trip_duration_key, R.integer.pref_general_trip_duration_defaultValue);
         public static final UserPreference<String> DefaultCurrency = new UserPreference<>(String.class, R.string.pref_general_default_currency_key, R.string.pref_general_default_currency_defaultValue);
         public static final UserPreference<String> DateSeparator = new UserPreference<>(String.class, R.string.pref_general_default_date_separator_key, R.string.pref_general_default_date_separator_defaultValue);
+        public static final UserPreference<String> DateFormat = new UserPreference<>(String.class, R.string.pref_general_date_format_key, R.string.pref_general_date_format_defaultValue);
         public static final UserPreference<Boolean> IncludeCostCenter = new UserPreference<>(Boolean.class, R.string.pref_general_track_cost_center_key, R.bool.pref_general_track_cost_center_defaultValue);
     }
 

--- a/app/src/main/java/co/smartreceipts/android/utils/rx/RxSchedulers.kt
+++ b/app/src/main/java/co/smartreceipts/android/utils/rx/RxSchedulers.kt
@@ -1,0 +1,23 @@
+package co.smartreceipts.android.utils.rx
+
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.schedulers.Schedulers
+
+/**
+ * Provides a series of constants that we can use in conjunction with Dagger to inject the desired
+ * [Schedulers] for dependency injection
+ */
+object RxSchedulers {
+    /**
+     * A constant value that should map to [Schedulers.io]
+     */
+    const val IO = "io"
+    /**
+     * A constant value that should map to [Schedulers.computation]
+     */
+    const val COMPUTATION = "computation"
+    /**
+     * A constant value that should map to [AndroidSchedulers.mainThread]
+     */
+    const val MAIN = "main"
+}

--- a/app/src/main/res/values/preference_defaults.xml
+++ b/app/src/main/res/values/preference_defaults.xml
@@ -4,6 +4,7 @@
     <integer name="pref_general_trip_duration_defaultValue">3</integer>
     <string name="pref_general_default_currency_defaultValue" />
     <string name="pref_general_default_date_separator_defaultValue" />
+    <string name="pref_general_date_format_defaultValue">@string/pref_general_date_format_default_entryValue</string>
     <bool name="pref_general_track_cost_center_defaultValue">false</bool>
 
     <!-- ============== Preference Receipt ================ -->

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -33,6 +33,18 @@
     <string name="pref_general_default_currency_title">Default Currency</string>
     <string name="pref_general_default_date_separator_key" translatable="false">dateseparator</string>
     <string name="pref_general_default_date_separator_title">Default Date Separator</string>
+    <string name="pref_general_date_format_key" translatable="false">dateformat</string>
+    <string name="pref_general_date_format_title">Preferred Date Format</string>
+    <string name="pref_general_date_format_default_entryValue" translatable="false">Default</string>
+    <string name="pref_general_date_format_M_d_yyyy_entryValue" translatable="false">M_d_yyyy</string>
+    <string name="pref_general_date_format_d_M_yyyy_entryValue" translatable="false">d_M_yyyy</string>
+    <string name="pref_general_date_format_yyyy_MM_dd_entryValue" translatable="false">yyyy_MM_dd</string>
+    <string-array name="pref_general_date_format_entryValues">
+        <item>@string/pref_general_date_format_default_entryValue</item>
+        <item>@string/pref_general_date_format_M_d_yyyy_entryValue</item>
+        <item>@string/pref_general_date_format_d_M_yyyy_entryValue</item>
+        <item>@string/pref_general_date_format_yyyy_MM_dd_entryValue</item>
+    </string-array>
     <string name="pref_general_track_cost_center_key" translatable="false">trackcostcenter</string>
     <string name="pref_general_track_cost_center_title">Track Cost Center</string>
     <string name="pref_general_track_cost_center_summaryOn">Include Cost Center For Reports</string>

--- a/app/src/main/res/xml/preference_legacy.xml
+++ b/app/src/main/res/xml/preference_legacy.xml
@@ -50,9 +50,13 @@
             android:key="@string/pref_general_default_currency_key"
             android:title="@string/pref_general_default_currency_title" />
         <wb.android.preferences.SummaryListPreference
-            android:defaultValue="@string/pref_general_default_date_separator_key"
             android:key="@string/pref_general_default_date_separator_key"
-            android:title="@string/pref_general_default_date_separator_title" />
+            android:title="@string/pref_general_default_date_separator_title"
+            android:defaultValue="@string/pref_general_default_date_separator_defaultValue" />
+        <wb.android.preferences.SummaryListPreference
+            android:key="@string/pref_general_date_format_key"
+            android:title="@string/pref_general_date_format_title"
+            android:defaultValue="@string/pref_general_date_format_defaultValue" />
         <CheckBoxPreference
             android:defaultValue="@bool/pref_general_track_cost_center_defaultValue"
             android:key="@string/pref_general_track_cost_center_key"

--- a/app/src/main/res/xml/preferences_general.xml
+++ b/app/src/main/res/xml/preferences_general.xml
@@ -15,7 +15,11 @@
         <wb.android.preferences.SummaryListPreference
             android:key="@string/pref_general_default_date_separator_key"
             android:title="@string/pref_general_default_date_separator_title"
-            android:defaultValue="@string/pref_general_default_date_separator_key" />
+            android:defaultValue="@string/pref_general_default_date_separator_defaultValue" />
+        <wb.android.preferences.SummaryListPreference
+            android:key="@string/pref_general_date_format_key"
+            android:title="@string/pref_general_date_format_title"
+            android:defaultValue="@string/pref_general_date_format_defaultValue" />
         <CheckBoxPreference
             android:key="@string/pref_general_track_cost_center_key"
             android:title="@string/pref_general_track_cost_center_title"

--- a/app/src/test/java/co/smartreceipts/android/date/DateFormatterTest.kt
+++ b/app/src/test/java/co/smartreceipts/android/date/DateFormatterTest.kt
@@ -1,0 +1,135 @@
+package co.smartreceipts.android.date
+
+import co.smartreceipts.android.settings.UserPreferenceManager
+import co.smartreceipts.android.settings.catalog.UserPreference
+import co.smartreceipts.android.utils.TestLocaleToggler
+import co.smartreceipts.android.utils.TestTimezoneToggler
+import com.nhaarman.mockito_kotlin.whenever
+import io.reactivex.Single
+import io.reactivex.schedulers.Schedulers
+import io.reactivex.subjects.PublishSubject
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import java.sql.Date
+import java.util.*
+
+/**
+ * Note: Be careful to generally avoid testing the results of [DateFormatter.DateFormatOption.Default],
+ * since this can differ based on the system OS
+ */
+@RunWith(RobolectricTestRunner::class)
+class DateFormatterTest {
+
+    companion object {
+        /**
+         * A timestamp for a date that occurs on January 31, 2019 in the America/New_York time ozne
+         */
+        private const val TIMESTAMP = 1548955843313
+
+        private const val DEFAULT_DATE_SEPARATOR = "/"
+        private val DEFAULT_DATE_FORMAT_STRING = RuntimeEnvironment.application.getString(DateFormatter.DateFormatOption.yyyy_MM_dd.stringResId)
+        private val TIMEZONE = TimeZone.getTimeZone("America/New_York")
+    }
+
+    private lateinit var dateFormatter: DateFormatter
+
+    private val context = RuntimeEnvironment.application
+
+    @Mock
+    private lateinit var userPreferenceManager: UserPreferenceManager
+
+    private val scheduler = Schedulers.trampoline()
+
+    private val userPreferenceChangeStream = PublishSubject.create<UserPreference<*>>()
+
+    @Before
+    fun setUp() {
+        TestLocaleToggler.setDefaultLocale(Locale.US)
+        TestTimezoneToggler.setDefaultTimeZone(TIMEZONE)
+
+        MockitoAnnotations.initMocks(this)
+        whenever(userPreferenceManager.userPreferenceChangeStream).thenReturn(userPreferenceChangeStream)
+        whenever(userPreferenceManager.getSingle(UserPreference.General.DateSeparator)).thenReturn(Single.just(DEFAULT_DATE_SEPARATOR))
+        whenever(userPreferenceManager.getSingle(UserPreference.General.DateFormat)).thenReturn(Single.just(DEFAULT_DATE_FORMAT_STRING))
+        dateFormatter = DateFormatter(context, userPreferenceManager, scheduler)
+        dateFormatter.initialize()
+    }
+
+    @After
+    fun tearDown() {
+        TestLocaleToggler.resetDefaultLocale()
+        TestTimezoneToggler.resetDefaultTimeZone()
+    }
+
+    @Test
+    fun getFormattedDateForEachOption() {
+        val displayableDate = DisplayableDate(Date(TIMESTAMP), TIMEZONE)
+        assertEquals("1/31/2019", dateFormatter.getFormattedDate(displayableDate, DateFormatter.DateFormatOption.M_d_yyyy))
+        assertEquals("31/1/2019", dateFormatter.getFormattedDate(displayableDate, DateFormatter.DateFormatOption.d_M_yyyy))
+        assertEquals("2019/01/31", dateFormatter.getFormattedDate(displayableDate, DateFormatter.DateFormatOption.yyyy_MM_dd))
+        // For default, just verify that it includes our date separator
+        assertTrue(dateFormatter.getFormattedDate(displayableDate, DateFormatter.DateFormatOption.Default).contains("/"))
+    }
+
+    @Test
+    fun getFormattedDateForDisplayableDate() {
+        val displayableDate = DisplayableDate(Date(TIMESTAMP), TIMEZONE)
+        assertEquals("2019/01/31", dateFormatter.getFormattedDate(displayableDate))
+    }
+
+    @Test
+    fun getFormattedDateForSqlDate() {
+        assertEquals("2019/01/31", dateFormatter.getFormattedDate(Date(TIMESTAMP), TIMEZONE))
+    }
+
+    @Test
+    fun getFormattedDateForJavaDate() {
+        assertEquals("2019/01/31", dateFormatter.getFormattedDate(java.util.Date(TIMESTAMP), TIMEZONE))
+    }
+
+    @Test
+    fun getFormattedDateWhenChangingFormat() {
+        // We test once beforehand to ensure that there are no issues with our internal caching
+        val displayableDate = DisplayableDate(Date(TIMESTAMP), TIMEZONE)
+        assertEquals("2019/01/31", dateFormatter.getFormattedDate(java.util.Date(TIMESTAMP), TIMEZONE))
+
+        // Now change the format
+        whenever(userPreferenceManager[UserPreference.General.DateFormat]).thenReturn(RuntimeEnvironment.application.getString(DateFormatter.DateFormatOption.M_d_yyyy.stringResId))
+        userPreferenceChangeStream.onNext(UserPreference.General.DateFormat)
+        assertEquals("1/31/2019", dateFormatter.getFormattedDate(displayableDate))
+    }
+
+    @Test
+    fun getFormattedDateWhenChangingSeparator() {
+        // We test once beforehand to ensure that there are no issues with our internal caching
+        val displayableDate = DisplayableDate(Date(TIMESTAMP), TIMEZONE)
+        assertEquals("2019/01/31", dateFormatter.getFormattedDate(java.util.Date(TIMESTAMP), TIMEZONE))
+
+        // Now change the format
+        whenever(userPreferenceManager[UserPreference.General.DateSeparator]).thenReturn("--")
+        userPreferenceChangeStream.onNext(UserPreference.General.DateSeparator)
+        assertEquals("2019--01--31", dateFormatter.getFormattedDate(displayableDate))
+    }
+
+    @Test
+    fun getFormattedDateWhenChangingFormatAndSeparator() {
+        // We test once beforehand to ensure that there are no issues with our internal caching
+        val displayableDate = DisplayableDate(Date(TIMESTAMP), TIMEZONE)
+        assertEquals("2019/01/31", dateFormatter.getFormattedDate(java.util.Date(TIMESTAMP), TIMEZONE))
+
+        // Now change the format
+        whenever(userPreferenceManager[UserPreference.General.DateFormat]).thenReturn(RuntimeEnvironment.application.getString(DateFormatter.DateFormatOption.M_d_yyyy.stringResId))
+        userPreferenceChangeStream.onNext(UserPreference.General.DateFormat)
+        whenever(userPreferenceManager[UserPreference.General.DateSeparator]).thenReturn("--")
+        userPreferenceChangeStream.onNext(UserPreference.General.DateSeparator)
+        assertEquals("1--31--2019", dateFormatter.getFormattedDate(displayableDate))
+    }
+}

--- a/app/src/test/java/co/smartreceipts/android/report/InteractivePdfBoxTest.java
+++ b/app/src/test/java/co/smartreceipts/android/report/InteractivePdfBoxTest.java
@@ -68,6 +68,7 @@ import co.smartreceipts.android.utils.shadows.ShadowFontFileFinder;
 import co.smartreceipts.android.workers.reports.ReportResourcesManager;
 import co.smartreceipts.android.workers.reports.pdf.pdfbox.PdfBoxReportFile;
 import co.smartreceipts.android.workers.reports.pdf.renderer.text.FallbackTextRenderer;
+import io.reactivex.schedulers.Schedulers;
 
 import static junit.framework.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -117,7 +118,7 @@ public class InteractivePdfBoxTest {
 
         context = RuntimeEnvironment.application;
         testResourceReader = new TestResourceReader();
-        dateFormatter = new DateFormatter(context, userPreferenceManager);
+        dateFormatter = new DateFormatter(context, userPreferenceManager, Schedulers.trampoline());
 
         when(persistenceManager.getPreferenceManager()).thenReturn(userPreferenceManager);
 

--- a/app/src/test/java/co/smartreceipts/android/settings/catalog/UserPreferenceTest.java
+++ b/app/src/test/java/co/smartreceipts/android/settings/catalog/UserPreferenceTest.java
@@ -25,6 +25,7 @@ public class UserPreferenceTest {
         Assert.assertTrue(userPreferences.contains(UserPreference.General.DefaultReportDuration));
         Assert.assertTrue(userPreferences.contains(UserPreference.General.DefaultCurrency));
         Assert.assertTrue(userPreferences.contains(UserPreference.General.DateSeparator));
+        Assert.assertTrue(userPreferences.contains(UserPreference.General.DateFormat));
         Assert.assertTrue(userPreferences.contains(UserPreference.General.IncludeCostCenter));
         Assert.assertTrue(userPreferences.contains(UserPreference.Receipts.MinimumReceiptPrice));
         Assert.assertTrue(userPreferences.contains(UserPreference.Receipts.DefaultTaxPercentage));
@@ -81,6 +82,10 @@ public class UserPreferenceTest {
         Assert.assertEquals(UserPreference.General.DateSeparator.getType(), String.class);
         Assert.assertEquals(name(UserPreference.General.DateSeparator), "dateseparator");
         Assert.assertEquals(UserPreference.General.DateSeparator.getDefaultValue(), R.string.pref_general_default_date_separator_defaultValue);
+
+        Assert.assertEquals(UserPreference.General.DateFormat.getType(), String.class);
+        Assert.assertEquals(name(UserPreference.General.DateFormat), "dateformat");
+        Assert.assertEquals(UserPreference.General.DateFormat.getDefaultValue(), R.string.pref_general_date_format_defaultValue);
 
         Assert.assertEquals(UserPreference.General.IncludeCostCenter.getType(), Boolean.class);
         Assert.assertEquals(name(UserPreference.General.IncludeCostCenter), "trackcostcenter");


### PR DESCRIPTION
A number of users have contacted me, asking how to change the date format of the app to use their preferred setting. While such a capability exists within Android, it only works if you change your phone's language setting (e.g. from en-US to en-UK). This is a rather convoluted mechanism for making this work, so I added it as a setting instead.

The commit includes four date format options:

- Default. The phone's base version
- M_d_yyyy. The en-US style
- d_M_yyyy. The en-UK (and most of the rest of the world) style
- yyyy_MM_dd. For user's that wish to start with the year