### PR TITLE
Disabled LeakCanary on Android O to P

### DIFF
--- a/app/src/main/java/co/smartreceipts/android/launch/OnLaunchDataPreFetcher.kt
+++ b/app/src/main/java/co/smartreceipts/android/launch/OnLaunchDataPreFetcher.kt
@@ -1,5 +1,6 @@
 package co.smartreceipts.android.launch
 
+import android.annotation.SuppressLint
 import co.smartreceipts.android.di.scopes.ApplicationScope
 import co.smartreceipts.android.persistence.LastTripMonitor
 import co.smartreceipts.android.persistence.database.controllers.impl.DistanceTableController
@@ -26,6 +27,7 @@ class OnLaunchDataPreFetcher @Inject constructor(private val tripTableController
     /**
      * Loads all trips and the receipt / distance entries for our last trip
      */
+    @SuppressLint("CheckResult")
     fun loadUserData() {
         tripTableController.get()
                 .subscribeOn(Schedulers.io())

--- a/app/src/main/java/co/smartreceipts/android/utils/leaks/MemoryLeakMonitor.kt
+++ b/app/src/main/java/co/smartreceipts/android/utils/leaks/MemoryLeakMonitor.kt
@@ -1,6 +1,7 @@
 package co.smartreceipts.android.utils.leaks
 
 import android.app.Application
+import android.os.Build
 import co.smartreceipts.android.di.scopes.ApplicationScope
 import co.smartreceipts.android.utils.RobolectricMonitor
 import co.smartreceipts.android.utils.log.Logger
@@ -16,9 +17,11 @@ import javax.inject.Inject
 class MemoryLeakMonitor @Inject constructor(private val application: Application) {
 
     fun initialize() {
+
         when {
             RobolectricMonitor.areUnitTestsRunning() -> Logger.debug(this, "Ignoring LeakCanary as we're running unit tests...")
             LeakCanary.isInAnalyzerProcess(application) -> Logger.debug(this, "Ignoring this process as it's the LeakCanary analyzer one...")
+            (Build.VERSION_CODES.O .. Build.VERSION_CODES.P).contains(Build.VERSION.SDK_INT) -> Logger.debug(this, "Ignoring LeakCanary on Android {} due to an Android bug. See https://github.com/square/leakcanary/issues/1081", Build.VERSION.SDK_INT)
             else -> LeakCanary.install(application)
         }
     }


### PR DESCRIPTION
According to square/leakcanary#1081, there's a bug in the Android framework that causes this memory leak for a few scenarios, including apps that support TabLayout navigation via ViewPager (like we do). Rather than deal with this steady stream or leaks, I have disabled LeakCanary for Android O, O_MR1, and P.