### PR TITLE
Show Backup recovery Tooltip for Plus users

### DIFF
--- a/app/src/main/java/co/smartreceipts/android/SmartReceiptsApplication.java
+++ b/app/src/main/java/co/smartreceipts/android/SmartReceiptsApplication.java
@@ -213,12 +213,12 @@ public class SmartReceiptsApplication extends Application implements HasActivity
 
         flex.initialize();
         userPreferenceManager.initialize();
+        purchaseManager.initialize(this);
         orderingPreferencesManager.initialize();
         dateFormatter.initialize();
         onLaunchDataPreFetcher.loadUserData();
         identityManager.initialize();
         pushManager.initialize();
-        purchaseManager.initialize(this);
         cognitoManager.initialize();
         ocrManager.initialize();
         crashReporter.initialize();

--- a/app/src/main/java/co/smartreceipts/android/analytics/events/Events.java
+++ b/app/src/main/java/co/smartreceipts/android/analytics/events/Events.java
@@ -89,6 +89,7 @@ public final class Events {
         public static final Event ClickedGenerateReportTip = new DefaultEvent(Category.Informational, "ClickedGenerateReportTip");
         public static final Event ClickedBackupReminderTip = new DefaultEvent(Category.Informational, "ClickedBackupReminderTip");
         public static final Event ClickedPrivacyPolicyTip = new DefaultEvent(Category.Informational, "ClickedPrivacyPolicyTip");
+        public static final Event ClickedAutomaticBackupRecoveryHintTip = new DefaultEvent(Category.Informational, "ClickedAutomaticBackupRecoveryHintTip");
         public static final Event ClickedManageCategories = new DefaultEvent(Category.Informational, "ClickedManageCategories");
         public static final Event ClickedManagePaymentMethods = new DefaultEvent(Category.Informational, "ClickedManagePaymentMethods");
     }

--- a/app/src/main/java/co/smartreceipts/android/purchases/PurchaseManager.java
+++ b/app/src/main/java/co/smartreceipts/android/purchases/PurchaseManager.java
@@ -144,6 +144,7 @@ public class PurchaseManager {
      * list of all entities that we own, and finally persisting all changes to our {@link PurchaseWallet}.
      */
     @SuppressLint("CheckResult")
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     public void initialize(@NonNull Application application) {
         Logger.debug(PurchaseManager.this, "Initializing the purchase manager");
         application.registerActivityLifecycleCallbacks(new PurchaseManagerActivityLifecycleCallbacks(this));

--- a/app/src/main/java/co/smartreceipts/android/tooltip/TooltipController.kt
+++ b/app/src/main/java/co/smartreceipts/android/tooltip/TooltipController.kt
@@ -6,7 +6,6 @@ import co.smartreceipts.android.tooltip.model.StaticTooltip
 import co.smartreceipts.android.tooltip.model.TooltipInteraction
 import com.hadisatrio.optional.Optional
 import io.reactivex.Completable
-import io.reactivex.Observable
 import io.reactivex.Single
 import io.reactivex.functions.Consumer
 

--- a/app/src/main/java/co/smartreceipts/android/tooltip/TooltipControllerProvider.kt
+++ b/app/src/main/java/co/smartreceipts/android/tooltip/TooltipControllerProvider.kt
@@ -1,6 +1,7 @@
 package co.smartreceipts.android.tooltip
 
 import co.smartreceipts.android.di.scopes.FragmentScope
+import co.smartreceipts.android.tooltip.backup.AutomaticBackupRecoveryHintUserController
 import co.smartreceipts.android.tooltip.model.StaticTooltip
 import co.smartreceipts.android.tooltip.privacy.PrivacyPolicyTooltipController
 import co.smartreceipts.android.tooltip.rating.AppRatingTooltipController
@@ -11,7 +12,8 @@ import javax.inject.Provider
  * Manages the process of mapping a given [StaticTooltip] to a [TooltipController] implementation
  */
 @FragmentScope
-class TooltipControllerProvider @Inject constructor(private val privacyPolicyTooltipProvider: Provider<PrivacyPolicyTooltipController>,
+class TooltipControllerProvider @Inject constructor(private val automaticBackupRecoveryHintTooltipProvider: Provider<AutomaticBackupRecoveryHintUserController>,
+                                                    private val privacyPolicyTooltipProvider: Provider<PrivacyPolicyTooltipController>,
                                                     private val appRatingTooltipProvider: Provider<AppRatingTooltipController>) {
 
     /**
@@ -22,6 +24,7 @@ class TooltipControllerProvider @Inject constructor(private val privacyPolicyToo
      */
     fun get(tooltip: StaticTooltip): TooltipController {
         return when (tooltip) {
+            StaticTooltip.AutomaticBackupRecoveryHint -> automaticBackupRecoveryHintTooltipProvider.get()
             StaticTooltip.PrivacyPolicy -> privacyPolicyTooltipProvider.get()
             StaticTooltip.RateThisApp -> appRatingTooltipProvider.get()
         }

--- a/app/src/main/java/co/smartreceipts/android/tooltip/TooltipPresenter.kt
+++ b/app/src/main/java/co/smartreceipts/android/tooltip/TooltipPresenter.kt
@@ -39,7 +39,7 @@ class TooltipPresenter @Inject constructor(view: StaticTooltipView,
                     return@fromCallable tooltipSingles
                 }.flatMap { tooltipSingles ->
                     if (tooltipSingles.isNotEmpty()) {
-                        return@flatMap Single.zip(tooltipSingles, { optionalTooltipsArrayAsObjects ->
+                        return@flatMap Single.zip(tooltipSingles) { optionalTooltipsArrayAsObjects ->
                             var result = Optional.absent<StaticTooltip>()
                             optionalTooltipsArrayAsObjects.forEach {
                                 @Suppress("UNCHECKED_CAST")
@@ -51,7 +51,7 @@ class TooltipPresenter @Inject constructor(view: StaticTooltipView,
                                 }
                             }
                             return@zip result
-                        })
+                        }
                     } else {
                         // Don't zip an empty list
                         return@flatMap Single.just(Optional.absent<StaticTooltip>())

--- a/app/src/main/java/co/smartreceipts/android/tooltip/backup/AutomaticBackupRecoveryHintRouter.kt
+++ b/app/src/main/java/co/smartreceipts/android/tooltip/backup/AutomaticBackupRecoveryHintRouter.kt
@@ -1,0 +1,23 @@
+package co.smartreceipts.android.tooltip.backup
+
+import co.smartreceipts.android.activities.NavigationHandler
+import co.smartreceipts.android.activities.SmartReceiptsActivity
+import co.smartreceipts.android.di.scopes.FragmentScope
+import javax.inject.Inject
+
+
+/**
+ * A router instance, which is responsible for navigating to our automatic backups page with the
+ * intention of allowing the user to access their previous backups
+ */
+@FragmentScope
+class AutomaticBackupRecoveryHintRouter @Inject constructor(val navigationHandler: NavigationHandler<SmartReceiptsActivity>) {
+
+    /**
+     * Routes to the automatic backups page with the intention of allowing the user to potentially
+     * recover from a past backup
+     */
+    fun navigateToAutomaticBackupConfiguration() {
+        this.navigationHandler.navigateToBackupMenu()
+    }
+}

--- a/app/src/main/java/co/smartreceipts/android/tooltip/backup/AutomaticBackupRecoveryHintUserController.kt
+++ b/app/src/main/java/co/smartreceipts/android/tooltip/backup/AutomaticBackupRecoveryHintUserController.kt
@@ -1,0 +1,76 @@
+package co.smartreceipts.android.tooltip.backup
+
+import android.support.annotation.AnyThread
+import android.support.annotation.UiThread
+import com.hadisatrio.optional.Optional
+
+import co.smartreceipts.android.analytics.Analytics
+import co.smartreceipts.android.analytics.events.Events
+import co.smartreceipts.android.di.scopes.FragmentScope
+import co.smartreceipts.android.purchases.PurchaseManager
+import co.smartreceipts.android.purchases.model.InAppPurchase
+import co.smartreceipts.android.purchases.wallet.PurchaseWallet
+import co.smartreceipts.android.tooltip.StaticTooltipView
+import co.smartreceipts.android.tooltip.TooltipController
+import co.smartreceipts.android.tooltip.model.StaticTooltip
+import co.smartreceipts.android.tooltip.model.TooltipInteraction
+import co.smartreceipts.android.utils.log.Logger
+import co.smartreceipts.android.utils.rx.RxSchedulers
+import io.reactivex.Completable
+import io.reactivex.Scheduler
+import io.reactivex.Single
+import io.reactivex.functions.BiFunction
+import io.reactivex.functions.Consumer
+import javax.inject.Inject
+import javax.inject.Named
+
+/**
+ * An implementation of the [TooltipController] contract to a hint to the user about attempting to
+ * recover a previous automatic backup
+ */
+@FragmentScope
+class AutomaticBackupRecoveryHintUserController @Inject constructor(private val tooltipView: StaticTooltipView,
+                                                                    private val router: AutomaticBackupRecoveryHintRouter,
+                                                                    private val store: AutomaticBackupRecoveryHintUserInteractionStore,
+                                                                    private val purchaseWallet: PurchaseWallet,
+                                                                    private val purchaseManager: PurchaseManager,
+                                                                    private val analytics: Analytics,
+                                                                    @Named(RxSchedulers.IO) private val scheduler: Scheduler) : TooltipController {
+
+    @UiThread
+    override fun shouldDisplayTooltip(): Single<Optional<StaticTooltip>> {
+        // Note: We fetch allOwnedPurchases first to ensure that the purchaseWallet is properly initialized
+        val userOwnsSmartReceiptsPlusSingle = purchaseManager.allOwnedPurchases
+                .map {
+                    return@map purchaseWallet.hasActivePurchase(InAppPurchase.SmartReceiptsPlus)
+                }
+                .firstOrError()
+
+        // Combine if an interaction has occurred (don't show) and if the user has plus (only show if they do)
+        return Single.zip(userOwnsSmartReceiptsPlusSingle, store.hasUserInteractionOccurred(), BiFunction<Boolean, Boolean, Boolean> { userOwnsPlus, userInteractionHasOccurred ->
+                    return@BiFunction userOwnsPlus and !userInteractionHasOccurred
+                })
+                .subscribeOn(scheduler)
+                .map { showTooltip -> if (showTooltip) Optional.of(StaticTooltip.AutomaticBackupRecoveryHint) else Optional.absent() }
+    }
+
+    @AnyThread
+    override fun handleTooltipInteraction(interaction: TooltipInteraction): Completable {
+        return Completable.fromCallable {
+            store.setUserHasInteractedWithAutomaticBackupRecoveryHint(true)
+            analytics.record(Events.Informational.ClickedAutomaticBackupRecoveryHintTip)
+            Logger.info(this@AutomaticBackupRecoveryHintUserController, "User interacted with the automatic backup recovery hint")
+        }.subscribeOn(scheduler)
+    }
+
+    @UiThread
+    override fun consumeTooltipInteraction(): Consumer<TooltipInteraction> {
+        return Consumer {
+            tooltipView.hideTooltip()
+            if (it == TooltipInteraction.TooltipClick) {
+                router.navigateToAutomaticBackupConfiguration()
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/co/smartreceipts/android/tooltip/backup/AutomaticBackupRecoveryHintUserInteractionStore.kt
+++ b/app/src/main/java/co/smartreceipts/android/tooltip/backup/AutomaticBackupRecoveryHintUserInteractionStore.kt
@@ -1,4 +1,4 @@
-package co.smartreceipts.android.tooltip.privacy
+package co.smartreceipts.android.tooltip.backup
 
 import android.content.SharedPreferences
 import co.smartreceipts.android.di.scopes.ApplicationScope
@@ -10,19 +10,19 @@ import javax.inject.Inject
 import javax.inject.Named
 
 @ApplicationScope
-class PrivacyPolicyUserInteractionStore @Inject constructor(private val preferences: Lazy<SharedPreferences>,
-                                                            @Named(RxSchedulers.IO) private val scheduler: Scheduler) {
+class AutomaticBackupRecoveryHintUserInteractionStore @Inject constructor(private val preferences: Lazy<SharedPreferences>,
+                                                                          @Named(RxSchedulers.IO) private val scheduler: Scheduler) {
 
     fun hasUserInteractionOccurred(): Single<Boolean> {
         return Single.fromCallable { preferences.get().getBoolean(KEY, false) }
                 .subscribeOn(scheduler)
     }
 
-    fun setUserHasInteractedWithPrivacyPolicy(hasUserInteractedWithPrivacyPolicy: Boolean) {
+    fun setUserHasInteractedWithAutomaticBackupRecoveryHint(hasUserInteractedWithPrivacyPolicy: Boolean) {
         preferences.get().edit().putBoolean(KEY, hasUserInteractedWithPrivacyPolicy).apply()
     }
 
     companion object {
-        private const val KEY = "user_click_privacy_prompt"
+        private const val KEY = "user_clicked_automatic_backup_recovery_hint"
     }
 }

--- a/app/src/main/java/co/smartreceipts/android/tooltip/backup/AutomaticBackupRecoveryHintVersionUpgradedListener.kt
+++ b/app/src/main/java/co/smartreceipts/android/tooltip/backup/AutomaticBackupRecoveryHintVersionUpgradedListener.kt
@@ -1,0 +1,25 @@
+package co.smartreceipts.android.tooltip.backup
+
+import co.smartreceipts.android.di.scopes.ApplicationScope
+import co.smartreceipts.android.utils.log.Logger
+import co.smartreceipts.android.versioning.VersionUpgradedListener
+import javax.inject.Inject
+
+
+/**
+ * A simple implementation of the [VersionUpgradedListener], which checks if the old version of the
+ * app was not set (i.e. equals -1), indicating that this is a fresh install. If this is an existing
+ * installation, we set inform the [AutomaticBackupRecoveryHintUserInteractionStore] that the user
+ * has already interacted with this tooltip (preventing it from appearing to existing users).
+ */
+@ApplicationScope
+class AutomaticBackupRecoveryHintVersionUpgradedListener @Inject constructor(private val store: AutomaticBackupRecoveryHintUserInteractionStore)
+    : VersionUpgradedListener {
+
+    override fun onVersionUpgrade(oldVersion: Int, newVersion: Int) {
+        if (oldVersion > 0) {
+            Logger.info(this, "Not a fresh install. Marking the automatic backup hint as already shown")
+            store.setUserHasInteractedWithAutomaticBackupRecoveryHint(true)
+        }
+    }
+}

--- a/app/src/main/java/co/smartreceipts/android/tooltip/model/StaticTooltip.kt
+++ b/app/src/main/java/co/smartreceipts/android/tooltip/model/StaticTooltip.kt
@@ -24,7 +24,8 @@ enum class StaticTooltip(val type: TooltipType,
                          val showCloseIcon: Boolean,
                          val showCancelButton: Boolean) {
 
-    PrivacyPolicy(TooltipType.Informational, 100, R.string.tooltip_review_privacy, false, true, false),
+    AutomaticBackupRecoveryHint(TooltipType.Informational, 100, R.string.tooltip_automatic_backups_recovery_hint, false, true, false),
+    PrivacyPolicy(TooltipType.Informational, 10, R.string.tooltip_review_privacy, false, true, false),
     RateThisApp(TooltipType.Question, 50, R.string.rating_tooltip_text, false, false, false)
 
 }

--- a/app/src/main/java/co/smartreceipts/android/tooltip/model/TooltipType.kt
+++ b/app/src/main/java/co/smartreceipts/android/tooltip/model/TooltipType.kt
@@ -11,7 +11,8 @@ enum class TooltipType {
     Informational,
 
     /**
-     * Indicates that this tooltip is asking an explicit question of this end user
+     * Indicates that this tooltip is asking an explicit question of this end user. This type
+     * differs from [Informational] in that it can multiple distinct actions (e.g. Yes, No).
      */
     Question,
 

--- a/app/src/main/java/co/smartreceipts/android/tooltip/privacy/PrivacyPolicyTooltipController.kt
+++ b/app/src/main/java/co/smartreceipts/android/tooltip/privacy/PrivacyPolicyTooltipController.kt
@@ -12,12 +12,13 @@ import co.smartreceipts.android.tooltip.TooltipController
 import co.smartreceipts.android.tooltip.model.StaticTooltip
 import co.smartreceipts.android.tooltip.model.TooltipInteraction
 import co.smartreceipts.android.utils.log.Logger
+import co.smartreceipts.android.utils.rx.RxSchedulers
 import io.reactivex.Completable
-import io.reactivex.Observable
+import io.reactivex.Scheduler
 import io.reactivex.Single
 import io.reactivex.functions.Consumer
-import io.reactivex.schedulers.Schedulers
 import javax.inject.Inject
+import javax.inject.Named
 
 /**
  * An implementation of the [TooltipController] contract to display a Privacy Policy tooltip
@@ -26,7 +27,8 @@ import javax.inject.Inject
 class PrivacyPolicyTooltipController @Inject constructor(private val tooltipView: StaticTooltipView,
                                                          private val router: PrivacyPolicyRouter,
                                                          private val store: PrivacyPolicyUserInteractionStore,
-                                                         private val analytics: Analytics) : TooltipController {
+                                                         private val analytics: Analytics,
+                                                         @Named(RxSchedulers.IO) private val scheduler: Scheduler) : TooltipController {
 
     @UiThread
     override fun shouldDisplayTooltip(): Single<Optional<StaticTooltip>> {
@@ -40,7 +42,7 @@ class PrivacyPolicyTooltipController @Inject constructor(private val tooltipView
             store.setUserHasInteractedWithPrivacyPolicy(true)
             analytics.record(Events.Informational.ClickedPrivacyPolicyTip)
             Logger.info(this@PrivacyPolicyTooltipController, "User interacted with the privacy policy settings information")
-        }.subscribeOn(Schedulers.io())
+        }.subscribeOn(scheduler)
     }
 
     @UiThread

--- a/app/src/main/java/co/smartreceipts/android/trips/TripFragment.java
+++ b/app/src/main/java/co/smartreceipts/android/trips/TripFragment.java
@@ -333,7 +333,7 @@ public class TripFragment extends WBListFragment implements TableEventsListener<
     @NotNull
     @Override
     public List<StaticTooltip> getSupportedTooltips() {
-        return Arrays.asList(StaticTooltip.PrivacyPolicy, StaticTooltip.RateThisApp);
+        return Arrays.asList(StaticTooltip.AutomaticBackupRecoveryHint, StaticTooltip.PrivacyPolicy, StaticTooltip.RateThisApp);
     }
 
     @Override

--- a/app/src/main/java/co/smartreceipts/android/versioning/AppVersionUpgradesList.kt
+++ b/app/src/main/java/co/smartreceipts/android/versioning/AppVersionUpgradesList.kt
@@ -1,6 +1,7 @@
 package co.smartreceipts.android.versioning
 
 import co.smartreceipts.android.di.scopes.ApplicationScope
+import co.smartreceipts.android.tooltip.backup.AutomaticBackupRecoveryHintVersionUpgradedListener
 import java.util.*
 import javax.inject.Inject
 
@@ -8,9 +9,9 @@ import javax.inject.Inject
  * Tracks the complete list of actions that we perform when we upgrade our application version
  */
 @ApplicationScope
-class AppVersionUpgradesList @Inject constructor() {
+class AppVersionUpgradesList @Inject constructor(private val automaticBackupRecoveryHintVersionUpgradedListener: AutomaticBackupRecoveryHintVersionUpgradedListener) {
 
     fun getUpgradeListeners() : List<VersionUpgradedListener> {
-        return Collections.emptyList()
+        return Collections.singletonList(automaticBackupRecoveryHintVersionUpgradedListener)
     }
 }

--- a/app/src/main/java/co/smartreceipts/android/versioning/VersionUpgradedListener.kt
+++ b/app/src/main/java/co/smartreceipts/android/versioning/VersionUpgradedListener.kt
@@ -8,7 +8,8 @@ interface VersionUpgradedListener {
      * Called when the application version was upgraded.
      *
      *
-     * This was added after version 78 was release, so version 79 was the first "new" one
+     * This was added after version 78 was release, so version 79 was the first "new" one. If this
+     * is a fresh install, the [oldVersion] will appear as -1
      *
      *
      * @param oldVersion the old application version

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -481,6 +481,7 @@
     <string name="tooltip_backup_info_message">%d Tage seit dein letztem Backup</string>
     <string name="tooltip_import_info_message">Bitte wählen Sie den Beleg für Ihren Anhang</string>
     <string name="tooltip_review_privacy">Tippen Sie hier, um Ihre Datenschutzeinstellungen zu überprüfen</string>
+    <string name="tooltip_automatic_backups_recovery_hint">Haben Sie zuvor automatische backups konfiguriert? Zum Wiederherstellen hier tippen</string>
 
     <!-- ================== Graph titles ==================== -->
     <string name="graphs_no_data">Fügen Sie Ihre ersten Quittungen hinzu, um Grafiken zu sehen.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -481,6 +481,7 @@
     <string name="tooltip_backup_info_message">%d días desde la última copia de seguridad</string>
     <string name="tooltip_import_info_message">Por favor, elija el recibo de su archivo adjunto</string>
     <string name="tooltip_review_privacy">Toca para revisar tu configuración de privacidad</string>
+    <string name="tooltip_automatic_backups_recovery_hint">¿Configuró previamente copias de seguridad automáticas? Toque aquí para restaurar</string>
 
     <!-- ================== Graph titles ==================== -->
     <string name="graphs_no_data">Agregue sus primeros recibos para ver los gráficos.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -481,6 +481,7 @@
     <string name="tooltip_backup_info_message">%d jours depuis votre dernière sauvegarde</string>
     <string name="tooltip_import_info_message">Veuillez choisir un reçu pour votre pièce jointe</string>
     <string name="tooltip_review_privacy">Appuyez pour examiner vos paramètres de confidentialité</string>
+    <string name="tooltip_automatic_backups_recovery_hint">Avez-vous déjà configuré des sauvegardes automatiques? Appuyez ici pour restaurer</string>
 
     <!-- ================== Graph titles ==================== -->
     <string name="graphs_no_data">Ajoutez vos premiers reçus pour voir les graphiques.</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -503,6 +503,7 @@
     <string name="tooltip_no_backups_info_message">תזכורת: גבה את המידע שלך באופן קבוע</string>
     <string name="tooltip_import_info_message">אנא בחר קבלה עבור הקובץ המצורף שלך</string>
     <string name="tooltip_review_privacy">לחץ לעיון של הגדרות הפרטיות שלך</string>
+    <string name="tooltip_automatic_backups_recovery_hint">האם הגדרת בעבר גיבויים אוטומטיים? הקש כאן כדי לשחזר</string>
 
     <!-- ================== Graph titles ==================== -->
     <string name="graphs_no_data">הוסף קבלות ראשונות על מנת לצפות בגרפים</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -481,6 +481,7 @@
     <string name="tooltip_backup_info_message">%d dias desde o último backup</string>
     <string name="tooltip_import_info_message">Por favor, escolha o recibo para o seu anexo</string>
     <string name="tooltip_review_privacy">Toque para rever suas configurações de privacidade</string>
+    <string name="tooltip_automatic_backups_recovery_hint">Você configurou anteriormente backups automáticos? Toque aqui para restaurar</string>
 
     <!-- ================== Graph titles ==================== -->
     <string name="graphs_no_data">Adicione seus primeiros recibos para ver gráficos.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -483,6 +483,7 @@
     <string name="tooltip_backup_info_message">%d дней с момента вашего последнего бэкапа</string>
     <string name="tooltip_import_info_message">Пожалуйста, выберите чек для вашего вложения</string>
     <string name="tooltip_review_privacy">Нажмите, чтобы просмотреть настройки конфиденциальности</string>
+    <string name="tooltip_automatic_backups_recovery_hint">Вы ранее настраивали автоматическое резервное копирование? Нажмите здесь, чтобы восстановить</string>
 
     <!-- ================== Graph titles ==================== -->
     <string name="graphs_no_data">Добавьте свой первый чек чтобы увидеть графики.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -483,6 +483,7 @@
     <string name="tooltip_backup_info_message">%d днів з моменту останньої резервної копії</string>
     <string name="tooltip_import_info_message">Будь-ласка, оберіть чек для вашого вкладення</string>
     <string name="tooltip_review_privacy">Торкніться, щоб переглянути налаштування конфіденційності</string>
+    <string name="tooltip_automatic_backups_recovery_hint">Ви раніше налаштовували автоматичне резервне копіювання? Натисніть тут, щоб відновити</string>
 
     <!-- ================== Graph titles ==================== -->
     <string name="graphs_no_data">Додайте свій перший чек щоб побачити графіки.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -501,6 +501,7 @@
     <string name="tooltip_no_backups_info_message">Reminder: Periodically back up your data</string>
     <string name="tooltip_import_info_message">Please, choose receipt for your attachment</string>
     <string name="tooltip_review_privacy">Tap to review your privacy settings</string>
+    <string name="tooltip_automatic_backups_recovery_hint">Did you previously configure automatic backups? Tap to restore</string>
 
     <!-- ================== Graph titles ==================== -->
     <string name="graphs_no_data">Add your first receipts to see graphs.</string>

--- a/app/src/test/java/co/smartreceipts/android/tooltip/TooltipControllerProviderTest.kt
+++ b/app/src/test/java/co/smartreceipts/android/tooltip/TooltipControllerProviderTest.kt
@@ -1,5 +1,6 @@
 package co.smartreceipts.android.tooltip
 
+import co.smartreceipts.android.tooltip.backup.AutomaticBackupRecoveryHintUserController
 import co.smartreceipts.android.tooltip.model.StaticTooltip
 import co.smartreceipts.android.tooltip.privacy.PrivacyPolicyTooltipController
 import co.smartreceipts.android.tooltip.rating.AppRatingTooltipController
@@ -19,6 +20,9 @@ class TooltipControllerProviderTest {
     lateinit var tooltipControllerProvider: TooltipControllerProvider
 
     @Mock
+    lateinit var automaticBackupRecoveryHintUserController: AutomaticBackupRecoveryHintUserController
+
+    @Mock
     lateinit var privacyPolicyTooltipController: PrivacyPolicyTooltipController
 
     @Mock
@@ -27,8 +31,14 @@ class TooltipControllerProviderTest {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        tooltipControllerProvider = TooltipControllerProvider(Provider { return@Provider privacyPolicyTooltipController },
+        tooltipControllerProvider = TooltipControllerProvider(Provider { return@Provider automaticBackupRecoveryHintUserController },
+                                                              Provider { return@Provider privacyPolicyTooltipController },
                                                               Provider { return@Provider appRatingTooltipController })
+    }
+
+    @Test
+    fun getAutomaticBackupRecoveryHintUserController() {
+        assertTrue(tooltipControllerProvider.get(StaticTooltip.AutomaticBackupRecoveryHint) is AutomaticBackupRecoveryHintUserController)
     }
 
     @Test

--- a/app/src/test/java/co/smartreceipts/android/tooltip/TooltipPresenterTest.kt
+++ b/app/src/test/java/co/smartreceipts/android/tooltip/TooltipPresenterTest.kt
@@ -134,7 +134,7 @@ class TooltipPresenterTest {
         whenever(rateThisAppController.shouldDisplayTooltip()).thenReturn(Single.just(Optional.of(StaticTooltip.RateThisApp)))
         whenever(privacyPolicyController.shouldDisplayTooltip()).thenReturn(Single.just(Optional.of(StaticTooltip.PrivacyPolicy)))
         tooltipPresenter.subscribe()
-        verify(view).display(StaticTooltip.PrivacyPolicy)
+        verify(view).display(StaticTooltip.RateThisApp)
     }
 
 }

--- a/app/src/test/java/co/smartreceipts/android/tooltip/backup/AutomaticBackupRecoveryHintRouterTest.kt
+++ b/app/src/test/java/co/smartreceipts/android/tooltip/backup/AutomaticBackupRecoveryHintRouterTest.kt
@@ -1,0 +1,33 @@
+package co.smartreceipts.android.tooltip.backup
+
+import co.smartreceipts.android.activities.NavigationHandler
+import co.smartreceipts.android.activities.SmartReceiptsActivity
+import com.nhaarman.mockito_kotlin.verify
+import org.junit.Before
+import org.junit.Test
+
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AutomaticBackupRecoveryHintRouterTest {
+
+    lateinit var hintRouter: AutomaticBackupRecoveryHintRouter
+
+    @Mock
+    lateinit var navigationHandler: NavigationHandler<SmartReceiptsActivity>
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+        hintRouter = AutomaticBackupRecoveryHintRouter(navigationHandler)
+    }
+
+    @Test
+    fun navigateToPrivacyPolicyControls() {
+        hintRouter.navigateToAutomaticBackupConfiguration()
+        verify(navigationHandler).navigateToBackupMenu()
+    }
+}

--- a/app/src/test/java/co/smartreceipts/android/tooltip/backup/AutomaticBackupRecoveryHintUserControllerTest.kt
+++ b/app/src/test/java/co/smartreceipts/android/tooltip/backup/AutomaticBackupRecoveryHintUserControllerTest.kt
@@ -1,0 +1,130 @@
+package co.smartreceipts.android.tooltip.backup
+
+import co.smartreceipts.android.analytics.Analytics
+import co.smartreceipts.android.analytics.events.Events
+import co.smartreceipts.android.purchases.model.InAppPurchase
+import co.smartreceipts.android.purchases.wallet.PurchaseWallet
+import co.smartreceipts.android.tooltip.StaticTooltipView
+import co.smartreceipts.android.tooltip.model.StaticTooltip
+import co.smartreceipts.android.tooltip.model.TooltipInteraction
+import co.smartreceipts.android.tooltip.privacy.PrivacyPolicyRouter
+import co.smartreceipts.android.tooltip.privacy.PrivacyPolicyTooltipController
+import co.smartreceipts.android.tooltip.privacy.PrivacyPolicyUserInteractionStore
+import com.hadisatrio.optional.Optional
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.verifyZeroInteractions
+import com.nhaarman.mockito_kotlin.whenever
+import io.reactivex.Single
+import io.reactivex.schedulers.Schedulers
+import org.junit.Assert.*
+
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AutomaticBackupRecoveryHintUserControllerTest {
+
+    private lateinit var automaticBackupRecoveryHintUserController: AutomaticBackupRecoveryHintUserController
+
+    @Mock
+    private lateinit var tooltipView: StaticTooltipView
+
+    @Mock
+    private lateinit var router: AutomaticBackupRecoveryHintRouter
+
+    @Mock
+    private lateinit var store: AutomaticBackupRecoveryHintUserInteractionStore
+
+    @Mock
+    private lateinit var purchaseWallet: PurchaseWallet
+
+    @Mock
+    private lateinit var analytics: Analytics
+
+    private val scheduler = Schedulers.trampoline()
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+        automaticBackupRecoveryHintUserController = AutomaticBackupRecoveryHintUserController(tooltipView, router, store, purchaseWallet, analytics, scheduler)
+    }
+
+    @Test
+    fun displayTooltipWithNoInteractionsAndPlusSubscription() {
+        whenever(store.hasUserInteractionOccurred()).thenReturn(Single.just(false))
+        whenever(purchaseWallet.hasActivePurchase(InAppPurchase.SmartReceiptsPlus)).thenReturn(true)
+        automaticBackupRecoveryHintUserController.shouldDisplayTooltip()
+                .test()
+                .await()
+                .assertValue(Optional.of(StaticTooltip.AutomaticBackupRecoveryHint))
+                .assertComplete()
+                .assertNoErrors()
+    }
+
+    @Test
+    fun doNotDisplayTooltipWithNoInteractionsAndNoPlusSubscription() {
+        whenever(store.hasUserInteractionOccurred()).thenReturn(Single.just(false))
+        whenever(purchaseWallet.hasActivePurchase(InAppPurchase.SmartReceiptsPlus)).thenReturn(false)
+        automaticBackupRecoveryHintUserController.shouldDisplayTooltip()
+                .test()
+                .await()
+                .assertValue(Optional.absent())
+                .assertComplete()
+                .assertNoErrors()
+    }
+
+    @Test
+    fun doNotDisplayTooltipWithInteractionsAndNoPlusSubscription() {
+        whenever(store.hasUserInteractionOccurred()).thenReturn(Single.just(true))
+        whenever(purchaseWallet.hasActivePurchase(InAppPurchase.SmartReceiptsPlus)).thenReturn(false)
+        automaticBackupRecoveryHintUserController.shouldDisplayTooltip()
+                .test()
+                .await()
+                .assertValue(Optional.absent())
+                .assertComplete()
+                .assertNoErrors()
+    }
+
+    @Test
+    fun doNotDisplayTooltipWithInteractionsAndPlusSubscription() {
+        whenever(store.hasUserInteractionOccurred()).thenReturn(Single.just(true))
+        whenever(purchaseWallet.hasActivePurchase(InAppPurchase.SmartReceiptsPlus)).thenReturn(true)
+        automaticBackupRecoveryHintUserController.shouldDisplayTooltip()
+                .test()
+                .await()
+                .assertValue(Optional.absent())
+                .assertComplete()
+                .assertNoErrors()
+    }
+
+    @Test
+    fun handleTooltipInteraction() {
+        val interaction = TooltipInteraction.TooltipClick
+        automaticBackupRecoveryHintUserController.handleTooltipInteraction(interaction)
+                .test()
+                .await()
+                .assertComplete()
+                .assertNoErrors()
+
+        verify(store).setUserHasInteractedWithAutomaticBackupRecoveryHint(true)
+        verify(analytics).record(Events.Informational.ClickedAutomaticBackupRecoveryHintTip)
+    }
+
+    @Test
+    fun consumeTooltipClickInteraction() {
+        automaticBackupRecoveryHintUserController.consumeTooltipInteraction().accept(TooltipInteraction.TooltipClick)
+        verify(tooltipView).hideTooltip()
+        verify(router).navigateToAutomaticBackupConfiguration()
+    }
+
+    @Test
+    fun consumeTooltipCloseInteraction() {
+        automaticBackupRecoveryHintUserController.consumeTooltipInteraction().accept(TooltipInteraction.CloseCancelButtonClick)
+        verify(tooltipView).hideTooltip()
+        verifyZeroInteractions(router)
+    }
+}

--- a/app/src/test/java/co/smartreceipts/android/tooltip/backup/AutomaticBackupRecoveryHintUserControllerTest.kt
+++ b/app/src/test/java/co/smartreceipts/android/tooltip/backup/AutomaticBackupRecoveryHintUserControllerTest.kt
@@ -2,6 +2,7 @@ package co.smartreceipts.android.tooltip.backup
 
 import co.smartreceipts.android.analytics.Analytics
 import co.smartreceipts.android.analytics.events.Events
+import co.smartreceipts.android.purchases.PurchaseManager
 import co.smartreceipts.android.purchases.model.InAppPurchase
 import co.smartreceipts.android.purchases.wallet.PurchaseWallet
 import co.smartreceipts.android.tooltip.StaticTooltipView
@@ -14,6 +15,7 @@ import com.hadisatrio.optional.Optional
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.verifyZeroInteractions
 import com.nhaarman.mockito_kotlin.whenever
+import io.reactivex.Observable
 import io.reactivex.Single
 import io.reactivex.schedulers.Schedulers
 import org.junit.Assert.*
@@ -43,6 +45,9 @@ class AutomaticBackupRecoveryHintUserControllerTest {
     private lateinit var purchaseWallet: PurchaseWallet
 
     @Mock
+    private lateinit var purchaseManager: PurchaseManager
+
+    @Mock
     private lateinit var analytics: Analytics
 
     private val scheduler = Schedulers.trampoline()
@@ -50,7 +55,8 @@ class AutomaticBackupRecoveryHintUserControllerTest {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        automaticBackupRecoveryHintUserController = AutomaticBackupRecoveryHintUserController(tooltipView, router, store, purchaseWallet, analytics, scheduler)
+        whenever(purchaseManager.allOwnedPurchases).thenReturn(Observable.just(emptySet()))
+        automaticBackupRecoveryHintUserController = AutomaticBackupRecoveryHintUserController(tooltipView, router, store, purchaseWallet, purchaseManager, analytics, scheduler)
     }
 
     @Test

--- a/app/src/test/java/co/smartreceipts/android/tooltip/backup/AutomaticBackupRecoveryHintUserInteractionStoreTest.kt
+++ b/app/src/test/java/co/smartreceipts/android/tooltip/backup/AutomaticBackupRecoveryHintUserInteractionStoreTest.kt
@@ -1,20 +1,20 @@
-package co.smartreceipts.android.tooltip.privacy
+package co.smartreceipts.android.tooltip.backup
 
 import android.preference.PreferenceManager
 import co.smartreceipts.android.utils.TestLazy
 import io.reactivex.schedulers.Schedulers
 import org.junit.After
-
 import org.junit.Before
 import org.junit.Test
+
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
-class PrivacyPolicyUserInteractionStoreTest {
+class AutomaticBackupRecoveryHintUserInteractionStoreTest {
 
-    private lateinit var privacyPolicyUserInteractionStore: PrivacyPolicyUserInteractionStore
+    private lateinit var automaticBackupRecoveryHintUserInteractionStore: AutomaticBackupRecoveryHintUserInteractionStore
 
     private val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(RuntimeEnvironment.application)
 
@@ -22,7 +22,7 @@ class PrivacyPolicyUserInteractionStoreTest {
 
     @Before
     fun setUp() {
-        privacyPolicyUserInteractionStore = PrivacyPolicyUserInteractionStore(TestLazy.create(sharedPreferences), scheduler)
+        automaticBackupRecoveryHintUserInteractionStore = AutomaticBackupRecoveryHintUserInteractionStore(TestLazy.create(sharedPreferences), scheduler)
     }
 
     @After
@@ -32,7 +32,7 @@ class PrivacyPolicyUserInteractionStoreTest {
 
     @Test
     fun hasUserInteractionOccurredDefaultsToFalse() {
-        privacyPolicyUserInteractionStore.hasUserInteractionOccurred()
+        automaticBackupRecoveryHintUserInteractionStore.hasUserInteractionOccurred()
                 .test()
                 .await()
                 .assertValue(false)
@@ -42,15 +42,15 @@ class PrivacyPolicyUserInteractionStoreTest {
 
     @Test
     fun setUserHasInteractedWithPrivacyPolicy() {
-        privacyPolicyUserInteractionStore.setUserHasInteractedWithPrivacyPolicy(true)
-        privacyPolicyUserInteractionStore.hasUserInteractionOccurred()
+        automaticBackupRecoveryHintUserInteractionStore.setUserHasInteractedWithAutomaticBackupRecoveryHint(true)
+        automaticBackupRecoveryHintUserInteractionStore.hasUserInteractionOccurred()
                 .test()
                 .await()
                 .assertValue(true)
                 .assertComplete()
                 .assertNoErrors()
 
-        val newInstance = PrivacyPolicyUserInteractionStore(TestLazy.create(sharedPreferences), scheduler)
+        val newInstance = AutomaticBackupRecoveryHintUserInteractionStore(TestLazy.create(sharedPreferences), scheduler)
         newInstance.hasUserInteractionOccurred()
                 .test()
                 .await()

--- a/app/src/test/java/co/smartreceipts/android/tooltip/backup/AutomaticBackupRecoveryHintVersionUpgradedListenerTest.kt
+++ b/app/src/test/java/co/smartreceipts/android/tooltip/backup/AutomaticBackupRecoveryHintVersionUpgradedListenerTest.kt
@@ -1,0 +1,38 @@
+package co.smartreceipts.android.tooltip.backup
+
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.verifyZeroInteractions
+import org.junit.Before
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AutomaticBackupRecoveryHintVersionUpgradedListenerTest {
+
+    private lateinit var listener: AutomaticBackupRecoveryHintVersionUpgradedListener
+
+    @Mock
+    private lateinit var store: AutomaticBackupRecoveryHintUserInteractionStore
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+        listener = AutomaticBackupRecoveryHintVersionUpgradedListener(store)
+    }
+
+    @Test
+    fun onVersionUpgradeFromExistingVersionInformsTheStoreThatAnInteractionHasOccurred() {
+        listener.onVersionUpgrade(100, 200)
+        verify(store).setUserHasInteractedWithAutomaticBackupRecoveryHint(true)
+    }
+
+    @Test
+    fun onVersionUpgradeFromFreshInstallDoesNothing() {
+        listener.onVersionUpgrade(-1, 200)
+        verifyZeroInteractions(store)
+    }
+}

--- a/app/src/test/java/co/smartreceipts/android/tooltip/privacy/PrivacyPolicyTooltipControllerTest.kt
+++ b/app/src/test/java/co/smartreceipts/android/tooltip/privacy/PrivacyPolicyTooltipControllerTest.kt
@@ -13,6 +13,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import com.nhaarman.mockito_kotlin.*
+import io.reactivex.schedulers.Schedulers
 import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
 
@@ -33,10 +34,12 @@ class PrivacyPolicyTooltipControllerTest {
     @Mock
     lateinit var analytics: Analytics
 
+    private val scheduler = Schedulers.trampoline()
+
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        privacyPolicyTooltipController = PrivacyPolicyTooltipController(tooltipView, router, store, analytics)
+        privacyPolicyTooltipController = PrivacyPolicyTooltipController(tooltipView, router, store, analytics, scheduler)
     }
 
     @Test

--- a/app/src/test/java/co/smartreceipts/android/utils/TestLazy.kt
+++ b/app/src/test/java/co/smartreceipts/android/utils/TestLazy.kt
@@ -1,0 +1,25 @@
+package co.smartreceipts.android.utils
+
+import dagger.Lazy
+import dagger.internal.DoubleCheck
+import dagger.internal.Factory
+import dagger.internal.InstanceFactory
+
+/**
+ * A simple wrapper around Dagger2 [DoubleCheck] and [InstanceFactory] code, which is
+ * designed to allow us to easily create [Lazy] instances for our testing purposes
+ */
+object TestLazy {
+
+    /**
+     * Create a [Lazy] provider of [T]
+     *
+     * @param t the item to be lazily returned
+     * @param <T> the parameterized type, [T]
+     * @return a [Lazy] provider of [T]
+     */
+    @JvmStatic
+    fun <T> create(t: T): Lazy<T> {
+        return DoubleCheck.lazy<Factory<T>, T>(InstanceFactory.create<T>(t))
+    }
+}

--- a/app/src/test/java/co/smartreceipts/android/versioning/AppVersionManagerTest.kt
+++ b/app/src/test/java/co/smartreceipts/android/versioning/AppVersionManagerTest.kt
@@ -3,12 +3,14 @@ package co.smartreceipts.android.versioning
 import android.content.Context
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
+import android.os.Build
 import co.smartreceipts.android.settings.UserPreferenceManager
 import co.smartreceipts.android.settings.catalog.UserPreference
 import com.nhaarman.mockito_kotlin.*
 import io.reactivex.Observable
 import io.reactivex.schedulers.Schedulers
 import org.junit.Before
+import org.junit.Ignore
 
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -17,6 +19,7 @@ import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
 import java.util.*
 
 @RunWith(RobolectricTestRunner::class)
@@ -66,7 +69,7 @@ class AppVersionManagerTest {
 
         appVersionManager.onLaunch()
         verifyZeroInteractions(versionUpgradedListener1, versionUpgradedListener2)
-        verify(userPreferenceManager, never()).set(UserPreference.Internal.ApplicationVersionCode, newVersion)
+        verify(userPreferenceManager, never())[UserPreference.Internal.ApplicationVersionCode] = newVersion
     }
 
     @Test
@@ -77,7 +80,32 @@ class AppVersionManagerTest {
         appVersionManager.onLaunch()
         verify(versionUpgradedListener1).onVersionUpgrade(OLD_VERSION, newVersion)
         verify(versionUpgradedListener2).onVersionUpgrade(OLD_VERSION, newVersion)
-        verify(userPreferenceManager).set(UserPreference.Internal.ApplicationVersionCode, newVersion)
+        verify(userPreferenceManager)[UserPreference.Internal.ApplicationVersionCode] = newVersion
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.P])
+    @Ignore("Ignoring until we upgrade to Robolectric 4.x")
+    fun onLaunchWithNewVersionThatIsTheSameAsTheOldUsingSdk28() {
+        val newVersion = OLD_VERSION
+        packageInfo.longVersionCode = newVersion.toLong()
+
+        appVersionManager.onLaunch()
+        verifyZeroInteractions(versionUpgradedListener1, versionUpgradedListener2)
+        verify(userPreferenceManager, never())[UserPreference.Internal.ApplicationVersionCode] = newVersion
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.P])
+    @Ignore("Ignoring until we upgrade to Robolectric 4.x")
+    fun onLaunchWithNewVersionThatIsAboveTheOldUsingSdk28() {
+        val newVersion = OLD_VERSION + 1
+        packageInfo.longVersionCode = newVersion.toLong()
+
+        appVersionManager.onLaunch()
+        verify(versionUpgradedListener1).onVersionUpgrade(OLD_VERSION, newVersion)
+        verify(versionUpgradedListener2).onVersionUpgrade(OLD_VERSION, newVersion)
+        verify(userPreferenceManager)[UserPreference.Internal.ApplicationVersionCode] = newVersion
     }
 
     @Test
@@ -87,7 +115,7 @@ class AppVersionManagerTest {
 
         appVersionManager.onLaunch()
         verifyZeroInteractions(versionUpgradedListener1, versionUpgradedListener2)
-        verify(userPreferenceManager, never()).set(UserPreference.Internal.ApplicationVersionCode, newVersion)
+        verify(userPreferenceManager, never())[UserPreference.Internal.ApplicationVersionCode] = newVersion
     }
 
 }

--- a/app/src/test/java/co/smartreceipts/android/versioning/AppVersionUpgradesListTest.kt
+++ b/app/src/test/java/co/smartreceipts/android/versioning/AppVersionUpgradesListTest.kt
@@ -1,0 +1,31 @@
+package co.smartreceipts.android.versioning
+
+import co.smartreceipts.android.tooltip.backup.AutomaticBackupRecoveryHintVersionUpgradedListener
+import org.junit.Assert.*
+
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AppVersionUpgradesListTest {
+
+    private lateinit var upgradesList: AppVersionUpgradesList
+
+    @Mock
+    private lateinit var automaticBackupRecoveryHintVersionUpgradedListener: AutomaticBackupRecoveryHintVersionUpgradedListener
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+        upgradesList = AppVersionUpgradesList(automaticBackupRecoveryHintVersionUpgradedListener)
+    }
+
+    @Test
+    fun getUpgradeListeners() {
+        assertEquals(listOf(automaticBackupRecoveryHintVersionUpgradedListener), upgradesList.getUpgradeListeners())
+    }
+}


### PR DESCRIPTION
When a Smart Receipts Plus user launches the app for the first time, he/she is not given any hint as to how to restore from their automatic backups. This causes confusion (e.g. "Is my data lost?") even though all the data is still there. The user simply needs to re-configure Google Drive.

To help reduce this, we're using this change to show a tooltip when:

- The app was launched for the first time
- The user has a valid SmartReceiptsPlus subscription