### PR TITLE
Only show our privacy prompt on the first launch for EU users

### DIFF
--- a/app/src/main/java/co/smartreceipts/android/tooltip/privacy/PrivacyPolicyTooltipController.kt
+++ b/app/src/main/java/co/smartreceipts/android/tooltip/privacy/PrivacyPolicyTooltipController.kt
@@ -7,6 +7,7 @@ import com.hadisatrio.optional.Optional
 import co.smartreceipts.android.analytics.Analytics
 import co.smartreceipts.android.analytics.events.Events
 import co.smartreceipts.android.di.scopes.FragmentScope
+import co.smartreceipts.android.persistence.database.controllers.impl.TripTableController
 import co.smartreceipts.android.tooltip.StaticTooltipView
 import co.smartreceipts.android.tooltip.TooltipController
 import co.smartreceipts.android.tooltip.model.StaticTooltip
@@ -21,19 +22,53 @@ import javax.inject.Inject
 import javax.inject.Named
 
 /**
- * An implementation of the [TooltipController] contract to display a Privacy Policy tooltip
+ * An implementation of the [TooltipController] contract to display a Privacy Policy tooltip. This
+ * helps us to inform the user about his/her privacy rights in conjunction with the GDPR. We
+ * likely don't need this as the app makes a point of disabling the more PII/questionable tracking
+ * items by default, but it's a good addition to be safe.
+ *
+ * The rules for showing this item are:
+ *  - If the user interacted with the privacy policy tooltip, don't show it again
+ *  - If the user has not interacted with this tooltip, show it if the user is in the EU
+ *  - If the user has not interacted with this tooltip and the user is not in the EU, don't show it
+ *  until after the user has created his/her first trip (to avoid from confusing new users from
+ *  how to use the app, since we have a lot of settings)
  */
 @FragmentScope
 class PrivacyPolicyTooltipController @Inject constructor(private val tooltipView: StaticTooltipView,
                                                          private val router: PrivacyPolicyRouter,
                                                          private val store: PrivacyPolicyUserInteractionStore,
+                                                         private val regionChecker: RegionChecker,
+                                                         private val tripTableController: TripTableController,
                                                          private val analytics: Analytics,
                                                          @Named(RxSchedulers.IO) private val scheduler: Scheduler) : TooltipController {
 
     @UiThread
     override fun shouldDisplayTooltip(): Single<Optional<StaticTooltip>> {
         return store.hasUserInteractionOccurred()
-                .map { hasUserInteractionOccurred -> if (!hasUserInteractionOccurred) Optional.of(StaticTooltip.PrivacyPolicy) else Optional.absent() }
+                .flatMap { hasUserInteractionOccurred ->
+                    if (hasUserInteractionOccurred) {
+                        // If an interaction has already occurred, don't show the privacy tooltip again
+                        return@flatMap Single.just<Optional<StaticTooltip>>(Optional.absent())
+                    } else {
+                        if (regionChecker.isInTheEuropeanUnion()) {
+                            Logger.debug(this, "The user is in the EU. Indicating that we can display the privacy tooltip...")
+                            return@flatMap Single.just(Optional.of(StaticTooltip.PrivacyPolicy))
+                        } else {
+                            return@flatMap tripTableController.get()
+                                    .map { trips -> trips.size }
+                                    .map { tripCount ->
+                                        if (tripCount > 0) {
+                                            Logger.debug(this, "The user is NOT in the EU but we have at least one trip. Indicating that we can display the privacy tooltip...")
+                                            return@map Optional.of(StaticTooltip.PrivacyPolicy)
+                                        } else {
+                                            Logger.debug(this, "The user is NOT in the EU and we have no trips. Ignoring the privacy tooltip for now...")
+                                            return@map Optional.absent<StaticTooltip>()
+                                        }
+                                    }
+                        }
+                    }
+                }
     }
 
     @AnyThread

--- a/app/src/main/java/co/smartreceipts/android/tooltip/privacy/RegionChecker.kt
+++ b/app/src/main/java/co/smartreceipts/android/tooltip/privacy/RegionChecker.kt
@@ -1,0 +1,96 @@
+package co.smartreceipts.android.tooltip.privacy
+
+import android.content.Context
+import android.telephony.TelephonyManager
+import co.smartreceipts.android.di.scopes.ApplicationScope
+import java.util.*
+import javax.inject.Inject
+
+
+/**
+ * Allows us to quickly check a specific region for scenarios in which app business logic differs as
+ * per the user's region
+ */
+@ApplicationScope
+class RegionChecker internal constructor(private val telephonyManager: TelephonyManager?) {
+
+    @Inject
+    constructor(context: Context) : this(context.getSystemService(Context.TELEPHONY_SERVICE) as? TelephonyManager)
+
+    /**
+     * Checks if the user's phone is an EU model (useful for GDPR prompts)
+     *
+     * @return true if this is an EU model phone. false otherwise
+     */
+    fun isInTheEuropeanUnion() : Boolean {
+        return EU_COUNTRY_CODES.contains(getUserIso3166CountryCode())
+    }
+
+    /**
+     * Gets the two-character country iso code for the current user based on a combination of their
+     * telephone network, SIM card, and default locale
+     *
+     * @return the Iso 3166 country country code
+     */
+    private fun getUserIso3166CountryCode() : String {
+        // First, check the country code from the mobile network
+        // Note: The docs state that this may be unreliable on CDMA networks, so we ignore this check here
+        if (telephonyManager?.phoneType != TelephonyManager.PHONE_TYPE_CDMA) {
+            val networkCountryIso = telephonyManager?.networkCountryIso
+            if (networkCountryIso?.isNotEmpty() == true) {
+                return networkCountryIso.toUpperCase(Locale.US)
+            }
+        }
+
+        // Next, check it from the SIM card
+        val simCountryIso = telephonyManager?.simCountryIso
+        if (simCountryIso?.isNotEmpty() == true) {
+            return simCountryIso.toUpperCase(Locale.US)
+        }
+
+        // Finally, return the current locale
+        return Locale.getDefault().country.toUpperCase(Locale.US)
+    }
+
+    companion object {
+        /**
+         * This array contains a list of all known EU country codes
+         *
+         * From: https://ec.europa.eu/eurostat/statistics-explained/index.php/Tutorial:Country_codes_and_protocol_order
+         */
+        private val EU_COUNTRY_CODES = arrayListOf(
+                "BE",
+                "BG",
+                "CZ",
+                "DK",
+                "DE",
+                "EE",
+                "IE",
+                "EL",
+                "ES",
+                "FR",
+                "HR",
+                "IT",
+                "CY",
+                "LV",
+                "LT",
+                "LU",
+                "HU",
+                "MT",
+                "NL",
+                "AT",
+                "PL",
+                "PT",
+                "RO",
+                "SI",
+                "SK",
+                "FI",
+                "SE",
+                "UK",
+                "IS",
+                "LI",
+                "NO",
+                "CH"
+        )
+    }
+}

--- a/app/src/test/java/co/smartreceipts/android/tooltip/privacy/RegionCheckerTest.kt
+++ b/app/src/test/java/co/smartreceipts/android/tooltip/privacy/RegionCheckerTest.kt
@@ -1,0 +1,81 @@
+package co.smartreceipts.android.tooltip.privacy
+
+import android.telephony.TelephonyManager
+import co.smartreceipts.android.utils.TestLocaleToggler
+import co.smartreceipts.android.utils.TestTimezoneToggler
+import com.nhaarman.mockito_kotlin.whenever
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+import java.util.*
+
+@RunWith(RobolectricTestRunner::class)
+class RegionCheckerTest {
+
+    private lateinit var regionChecker: RegionChecker
+
+    @Mock
+    private lateinit var telephonyManager: TelephonyManager
+
+    @Before
+    fun setUp() {
+        TestLocaleToggler.setDefaultLocale(Locale.US)
+        MockitoAnnotations.initMocks(this)
+        regionChecker = RegionChecker(telephonyManager)
+    }
+
+    @After
+    fun tearDown() {
+        TestLocaleToggler.resetDefaultLocale()
+    }
+
+    @Test
+    fun isInTheEuropeanUnionReturnsFalseForGSMPhonesWithUSNetworkCountryCode() {
+        whenever(telephonyManager.phoneType).thenReturn(TelephonyManager.PHONE_TYPE_GSM)
+        whenever(telephonyManager.networkCountryIso).thenReturn("US")
+        assertFalse(regionChecker.isInTheEuropeanUnion())
+    }
+
+    @Test
+    fun isInTheEuropeanUnionReturnsTrueForGSMPhonesWithDENetworkCountryCode() {
+        whenever(telephonyManager.phoneType).thenReturn(TelephonyManager.PHONE_TYPE_GSM)
+        whenever(telephonyManager.networkCountryIso).thenReturn("DE")
+        assertTrue(regionChecker.isInTheEuropeanUnion())
+    }
+
+    @Test
+    fun isInTheEuropeanUnionReturnsFalseForCDMAPhonesWithDENetworkCountryCodeInTheUSLocale() {
+        whenever(telephonyManager.phoneType).thenReturn(TelephonyManager.PHONE_TYPE_CDMA)
+        whenever(telephonyManager.networkCountryIso).thenReturn("DE")
+        assertFalse(regionChecker.isInTheEuropeanUnion())
+    }
+
+    @Test
+    fun isInTheEuropeanUnionReturnsFalseForGSMPhonesWithUSSimCountryCode() {
+        whenever(telephonyManager.simCountryIso).thenReturn("US")
+        assertFalse(regionChecker.isInTheEuropeanUnion())
+    }
+
+    @Test
+    fun isInTheEuropeanUnionReturnsTrueForGSMPhonesWithDESimCountryCode() {
+        whenever(telephonyManager.simCountryIso).thenReturn("DE")
+        assertTrue(regionChecker.isInTheEuropeanUnion())
+    }
+
+    @Test
+    fun isInTheEuropeanUnionReturnsFalseWhenNullTelephonyManagerDefaultsToUSLocale() {
+        assertFalse(RegionChecker(null).isInTheEuropeanUnion())
+    }
+
+    @Test
+    fun isInTheEuropeanUnionReturnsTrueWhenNullTelephonyManagerDefaultsToDELocale() {
+        TestLocaleToggler.setDefaultLocale(Locale.GERMANY)
+        assertTrue(RegionChecker(null).isInTheEuropeanUnion())
+    }
+}

--- a/app/src/test/java/co/smartreceipts/android/utils/ParcelableTestUtil.kt
+++ b/app/src/test/java/co/smartreceipts/android/utils/ParcelableTestUtil.kt
@@ -8,7 +8,6 @@ import android.support.annotation.VisibleForTesting
 /**
  * From https://proandroiddev.com/testing-parcelize-114510f44c9a
  */
-
 @VisibleForTesting
 inline fun <reified R : Parcelable> R.testParcel(): R {
     val bytes = marshallParcelable(this)


### PR DESCRIPTION
At present, we show the "Tap to review your privacy settings" prompt to all users as per GDPR specifications. While user's have not explicitly complained about this, I am concerned that this may generally distract from the first time user experience and how to create a first expense report.

Rather than always show this on the first launch, I'd prefer that we do the following instead:

1. For EU users, show the privacy tooltip on first launch
2. For non-EU users, show the privacy tooltip on the trips screen after at least one trip has been created

Since we already respect the GDPR rules in the default config anyway, this change should be fine