### PR TITLE
[Bug] Our DateEditText instances do not respect our Date Format

### DIFF
--- a/app/src/main/java/co/smartreceipts/android/distance/editor/DistanceDialogFragment.java
+++ b/app/src/main/java/co/smartreceipts/android/distance/editor/DistanceDialogFragment.java
@@ -45,6 +45,7 @@ import co.smartreceipts.android.autocomplete.distance.DistanceAutoCompleteField;
 import co.smartreceipts.android.currency.widget.CurrencyListEditorPresenter;
 import co.smartreceipts.android.currency.widget.DefaultCurrencyListEditorView;
 import co.smartreceipts.android.date.DateEditText;
+import co.smartreceipts.android.date.DateFormatter;
 import co.smartreceipts.android.distance.editor.currency.DistanceCurrencyCodeSupplier;
 import co.smartreceipts.android.editor.Editor;
 import co.smartreceipts.android.model.Distance;
@@ -78,6 +79,9 @@ public class DistanceDialogFragment extends DialogFragment implements Editor<Dis
 
     @Inject
     UserPreferenceManager userPreferenceManager;
+
+    @Inject
+    DateFormatter dateFormatter;
 
     @Inject
     AutoCompletePresenter<Distance> distanceAutoCompletePresenter;
@@ -206,7 +210,7 @@ public class DistanceDialogFragment extends DialogFragment implements Editor<Dis
             builder.setTitle(getString(R.string.dialog_mileage_title_create));
             builder.setPositiveButton(getString(R.string.dialog_mileage_positive_create), this);
             dateEditText.setDate(suggestedDate);
-            dateEditText.setDateSeparator(userPreferenceManager.get(UserPreference.General.DateSeparator));
+            dateEditText.setDateFormatter(dateFormatter);
             final float distanceRate = userPreferenceManager.get(UserPreference.Distance.DefaultDistanceRate);
             if (distanceRate > 0) {
                 rateEditText.setText(ModelUtils.getDecimalFormattedValue(BigDecimal.valueOf(distanceRate), Distance.RATE_PRECISION));
@@ -223,7 +227,7 @@ public class DistanceDialogFragment extends DialogFragment implements Editor<Dis
             commentEditText.setText(updateableDistance.getComment());
             dateEditText.setDate(updateableDistance.getDate());
             dateEditText.setTimeZone(updateableDistance.getTimeZone());
-            dateEditText.setDateSeparator(userPreferenceManager.get(UserPreference.General.DateSeparator));
+            dateEditText.setDateFormatter(dateFormatter);
         }
         builder.setNegativeButton(android.R.string.cancel, this);
 

--- a/app/src/main/java/co/smartreceipts/android/receipts/editor/ReceiptCreateEditFragment.java
+++ b/app/src/main/java/co/smartreceipts/android/receipts/editor/ReceiptCreateEditFragment.java
@@ -61,6 +61,7 @@ import co.smartreceipts.android.currency.PriceCurrency;
 import co.smartreceipts.android.currency.widget.CurrencyListEditorPresenter;
 import co.smartreceipts.android.currency.widget.DefaultCurrencyListEditorView;
 import co.smartreceipts.android.date.DateEditText;
+import co.smartreceipts.android.date.DateFormatter;
 import co.smartreceipts.android.editor.Editor;
 import co.smartreceipts.android.fragments.ChildFragmentNavigationHandler;
 import co.smartreceipts.android.fragments.ReceiptInputCache;
@@ -145,6 +146,9 @@ public class ReceiptCreateEditFragment extends WBFragment implements Editor<Rece
 
     @Inject
     UserPreferenceManager userPreferenceManager;
+
+    @Inject
+    DateFormatter dateFormatter;
 
     @Inject
     ReceiptCreateEditFragmentPresenter presenter;
@@ -364,7 +368,7 @@ public class ReceiptCreateEditFragment extends WBFragment implements Editor<Rece
 
         // Outline date defaults
         dateBox.setFocusableInTouchMode(false);
-        dateBox.setDateSeparator(userPreferenceManager.get(UserPreference.General.DateSeparator));
+        dateBox.setDateFormatter(dateFormatter);
     }
 
     @Override

--- a/app/src/main/java/co/smartreceipts/android/trips/editor/TripCreateEditFragment.java
+++ b/app/src/main/java/co/smartreceipts/android/trips/editor/TripCreateEditFragment.java
@@ -48,6 +48,7 @@ import co.smartreceipts.android.currency.widget.CurrencyListEditorPresenter;
 import co.smartreceipts.android.currency.widget.CurrencyListEditorView;
 import co.smartreceipts.android.currency.widget.DefaultCurrencyListEditorView;
 import co.smartreceipts.android.date.DateEditText;
+import co.smartreceipts.android.date.DateFormatter;
 import co.smartreceipts.android.editor.Editor;
 import co.smartreceipts.android.fragments.WBFragment;
 import co.smartreceipts.android.model.Trip;
@@ -88,6 +89,9 @@ public class TripCreateEditFragment extends WBFragment implements Editor<Trip>,
 
     @Inject
     DatabaseHelper database;
+
+    @Inject
+    DateFormatter dateFormatter;
 
     @Inject
     TripCreateEditFragmentPresenter presenter;
@@ -200,8 +204,8 @@ public class TripCreateEditFragment extends WBFragment implements Editor<Trip>,
         nameBox.setKeyListener(input);
 
         // Configure default separators
-        startDateBox.setDateSeparator(userPreferenceManager.get(UserPreference.General.DateSeparator));
-        endDateBox.setDateSeparator(userPreferenceManager.get(UserPreference.General.DateSeparator));
+        startDateBox.setDateFormatter(dateFormatter);
+        endDateBox.setDateFormatter(dateFormatter);
 
         // Set Cost Center Visibility
         costCenterBoxLayout.setVisibility(presenter.isIncludeCostCenter() ? View.VISIBLE : View.GONE);


### PR DESCRIPTION
Following our work to Add support for a setting to customize date formatting options, We ensured that our `DateFormatter` works for models in the app, but we forgot to apply these settings to the `DateEditText` views themselves.

This fix ensures that we use our date formatter everywhere.