### PR TITLE
New "Enable Crop Image Screen" tooltip

### DIFF
--- a/app/src/main/java/co/smartreceipts/android/fragments/ReceiptImageFragment.kt
+++ b/app/src/main/java/co/smartreceipts/android/fragments/ReceiptImageFragment.kt
@@ -26,6 +26,7 @@ import co.smartreceipts.android.persistence.database.controllers.impl.ReceiptTab
 import co.smartreceipts.android.persistence.database.controllers.impl.StubTableEventsListener
 import co.smartreceipts.android.persistence.database.operations.DatabaseOperationMetadata
 import co.smartreceipts.android.persistence.database.operations.OperationFamilyType
+import co.smartreceipts.android.tooltip.image.data.ImageCroppingPreferenceStorage
 import co.smartreceipts.android.utils.IntentUtils
 import co.smartreceipts.android.utils.log.Logger
 import com.squareup.picasso.Callback
@@ -74,6 +75,9 @@ class ReceiptImageFragment : WBFragment() {
     lateinit var activityFileResultImporter: ActivityFileResultImporter
 
     @Inject
+    lateinit var imageCroppingPreferenceStorage: ImageCroppingPreferenceStorage
+
+    @Inject
     lateinit var picasso: Lazy<Picasso>
 
     private lateinit var receipt: Receipt
@@ -104,6 +108,7 @@ class ReceiptImageFragment : WBFragment() {
 
         rootView.button_edit_photo.setOnClickListener { view ->
             analytics.record(Events.Receipts.ReceiptImageViewEditPhoto)
+            imageCroppingPreferenceStorage.setCroppingScreenWasShown(true)
             navigationHandler.navigateToCropActivity(this, Uri.fromFile(receipt.file), RequestCodes.EDIT_IMAGE_CROP)
         }
 

--- a/app/src/main/java/co/smartreceipts/android/ocr/widget/tooltip/ReceiptCreateEditFragmentTooltipFragment.kt
+++ b/app/src/main/java/co/smartreceipts/android/ocr/widget/tooltip/ReceiptCreateEditFragmentTooltipFragment.kt
@@ -2,13 +2,10 @@ package co.smartreceipts.android.ocr.widget.tooltip
 
 import android.content.Context
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-
-import javax.inject.Inject
-
+import androidx.fragment.app.Fragment
 import co.smartreceipts.android.tooltip.TooltipPresenter
 import co.smartreceipts.android.tooltip.TooltipView
 import co.smartreceipts.android.tooltip.model.TooltipMetadata
@@ -16,6 +13,7 @@ import co.smartreceipts.android.tooltip.model.TooltipType
 import co.smartreceipts.android.widget.tooltip.Tooltip
 import dagger.android.support.AndroidSupportInjection
 import io.reactivex.Observable
+import javax.inject.Inject
 
 /**
  * Acts as a dedicated fragment for showing a tooltip when editing/creating a receipt.
@@ -48,7 +46,8 @@ class ReceiptCreateEditFragmentTooltipFragment : Fragment(), TooltipView {
     }
 
     override fun getSupportedTooltips(): List<TooltipType> {
-        return listOf(TooltipType.FirstReceiptUseTaxesQuestion, TooltipType.FirstReceiptUsePaymentMethodsQuestion, TooltipType.OcrInformation)
+        return listOf(TooltipType.FirstReceiptUseTaxesQuestion, TooltipType.FirstReceiptUsePaymentMethodsQuestion, TooltipType.OcrInformation,
+            TooltipType.ImageCropping)
     }
 
     override fun display(tooltip: TooltipMetadata) {

--- a/app/src/main/java/co/smartreceipts/android/receipts/ReceiptsListFragment.java
+++ b/app/src/main/java/co/smartreceipts/android/receipts/ReceiptsListFragment.java
@@ -78,6 +78,7 @@ import co.smartreceipts.android.receipts.ordering.ReceiptsOrderer;
 import co.smartreceipts.android.settings.UserPreferenceManager;
 import co.smartreceipts.android.settings.catalog.UserPreference;
 import co.smartreceipts.android.sync.BackupProvidersManager;
+import co.smartreceipts.android.tooltip.image.data.ImageCroppingPreferenceStorage;
 import co.smartreceipts.android.utils.ConfigurableResourceFeature;
 import co.smartreceipts.android.utils.log.Logger;
 import co.smartreceipts.android.widget.model.UiIndicator;
@@ -90,7 +91,6 @@ import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.schedulers.Schedulers;
 import wb.android.flex.Flex;
 
-import static android.app.Activity.RESULT_CANCELED;
 import static android.app.Activity.RESULT_OK;
 
 public class ReceiptsListFragment extends ReceiptsFragment implements ReceiptTableEventsListener, ReceiptCreateActionView,
@@ -159,6 +159,9 @@ public class ReceiptsListFragment extends ReceiptsFragment implements ReceiptTab
 
     @Inject
     Picasso picasso;
+
+    @Inject
+    ImageCroppingPreferenceStorage imageCroppingPreferenceStorage;
 
     @BindView(R.id.progress)
     ProgressBar loadingProgress;
@@ -479,9 +482,7 @@ public class ReceiptsListFragment extends ReceiptsFragment implements ReceiptTab
         if (RequestCodes.CROP_REQUESTS.contains(requestCode)) { // result from Crop Activity
             if (resultCode != UCrop.RESULT_ERROR) {
 
-                if (resultCode == RESULT_CANCELED) {
-                    Toast.makeText(requireContext(), R.string.toast_disable_crop_option, Toast.LENGTH_LONG).show();
-                }
+                imageCroppingPreferenceStorage.setCroppingScreenWasShown(true);
 
                 switch (requestCode) {
                     case RequestCodes.NEW_RECEIPT_CAMERA_IMAGE_CROP:

--- a/app/src/main/java/co/smartreceipts/android/tooltip/TooltipControllerProvider.kt
+++ b/app/src/main/java/co/smartreceipts/android/tooltip/TooltipControllerProvider.kt
@@ -3,6 +3,7 @@ package co.smartreceipts.android.tooltip
 import co.smartreceipts.android.di.scopes.FragmentScope
 import co.smartreceipts.android.ocr.widget.tooltip.OcrInformationTooltipController
 import co.smartreceipts.android.tooltip.backup.AutomaticBackupRecoveryHintUserController
+import co.smartreceipts.android.tooltip.image.ImageCroppingTooltipController
 import co.smartreceipts.android.tooltip.model.TooltipType
 import co.smartreceipts.android.tooltip.privacy.PrivacyPolicyTooltipController
 import co.smartreceipts.android.tooltip.rating.RateThisAppTooltipController
@@ -25,7 +26,8 @@ class TooltipControllerProvider @Inject constructor(private val automaticBackupR
                                                     private val rateThisAppTooltipProvider: Provider<RateThisAppTooltipController>,
                                                     private val ocrInformationTooltipProvider: Provider<OcrInformationTooltipController>,
                                                     private val firstReceiptUseTaxesQuestionTooltipProvider: Provider<FirstReceiptUseTaxesQuestionTooltipController>,
-                                                    private val firstReceiptUsePaymentMethodsQuestionTooltipProvider: Provider<FirstReceiptUsePaymentMethodsQuestionTooltipController>) {
+                                                    private val firstReceiptUsePaymentMethodsQuestionTooltipProvider: Provider<FirstReceiptUsePaymentMethodsQuestionTooltipController>,
+                                                    private val croppingTooltipProvider: Provider<ImageCroppingTooltipController>) {
 
     /**
      * Fetches the appropriate [TooltipController] for a given [TooltipType]
@@ -42,6 +44,7 @@ class TooltipControllerProvider @Inject constructor(private val automaticBackupR
             TooltipType.OcrInformation -> ocrInformationTooltipProvider.get()
             TooltipType.FirstReceiptUseTaxesQuestion -> firstReceiptUseTaxesQuestionTooltipProvider.get()
             TooltipType.FirstReceiptUsePaymentMethodsQuestion -> firstReceiptUsePaymentMethodsQuestionTooltipProvider.get()
+            TooltipType.ImageCropping -> croppingTooltipProvider.get()
         }
     }
 }

--- a/app/src/main/java/co/smartreceipts/android/tooltip/image/ImageCroppingTooltipController.kt
+++ b/app/src/main/java/co/smartreceipts/android/tooltip/image/ImageCroppingTooltipController.kt
@@ -1,0 +1,79 @@
+package co.smartreceipts.android.tooltip.image
+
+import android.content.Context
+import androidx.annotation.AnyThread
+import androidx.annotation.UiThread
+import co.smartreceipts.android.R
+import co.smartreceipts.android.di.scopes.FragmentScope
+import co.smartreceipts.android.settings.UserPreferenceManager
+import co.smartreceipts.android.settings.catalog.UserPreference
+import co.smartreceipts.android.tooltip.TooltipController
+import co.smartreceipts.android.tooltip.TooltipView
+import co.smartreceipts.android.tooltip.image.data.ImageCroppingPreferenceStorage
+import co.smartreceipts.android.tooltip.model.TooltipInteraction
+import co.smartreceipts.android.tooltip.model.TooltipMetadata
+import co.smartreceipts.android.tooltip.model.TooltipType
+import co.smartreceipts.android.utils.log.Logger
+import com.hadisatrio.optional.Optional
+import io.reactivex.Completable
+import io.reactivex.Observable
+import io.reactivex.Single
+import io.reactivex.functions.BiFunction
+import io.reactivex.functions.Consumer
+import io.reactivex.schedulers.Schedulers
+import javax.inject.Inject
+
+/**
+ * An implementation of the [TooltipController] contract to display a "Enable Cropping Yes|No" tooltip
+ */
+@FragmentScope
+class ImageCroppingTooltipController @Inject constructor(
+    private val context: Context,
+    private val tooltipView: TooltipView,
+    private val croppingPreferenceStorage: ImageCroppingPreferenceStorage,
+    private val preferences: UserPreferenceManager
+) : TooltipController {
+
+    @UiThread
+    override fun shouldDisplayTooltip(): Single<Optional<TooltipMetadata>> {
+
+        return Observable.combineLatest(croppingPreferenceStorage.getCroppingScreenWasShown().toObservable(),
+            croppingPreferenceStorage.getCroppingTooltipWasHandled().toObservable(),
+            BiFunction <Boolean, Boolean, Optional<TooltipMetadata>> { cropScreenWasShown, cropTooltipWasHandled ->
+                when {
+                    cropScreenWasShown && !cropTooltipWasHandled ->
+                        Optional.of(TooltipMetadata(TooltipType.ImageCropping, context.getString(R.string.pref_general_enable_crop_title)))
+                    else -> Optional.absent()
+                }
+            })
+            .lastOrError()
+    }
+
+    @AnyThread
+    override fun handleTooltipInteraction(interaction: TooltipInteraction): Completable {
+        return Completable.fromCallable {
+            croppingPreferenceStorage.setCroppingTooltipWasHandled(true)
+
+            when (interaction) {
+                TooltipInteraction.YesButtonClick -> {
+                    preferences.set(UserPreference.General.EnableCrop, true)
+                    Logger.info(this, "User clicked 'Yes' on the image cropping tooltip")
+                }
+                TooltipInteraction.NoButtonClick -> {
+                    preferences.set(UserPreference.General.EnableCrop, false)
+                    Logger.info(this, "User clicked 'No' on the image cropping tooltip")
+                }
+                else -> Logger.warn(this, "Handling unknown tooltip interaction: {}", interaction)
+            }
+        }.subscribeOn(Schedulers.io())
+    }
+
+    @UiThread
+    override fun consumeTooltipInteraction(): Consumer<TooltipInteraction> {
+        return Consumer {
+            tooltipView.hideTooltip()
+        }
+    }
+
+
+}

--- a/app/src/main/java/co/smartreceipts/android/tooltip/image/data/ImageCroppingPreferenceStorage.kt
+++ b/app/src/main/java/co/smartreceipts/android/tooltip/image/data/ImageCroppingPreferenceStorage.kt
@@ -1,0 +1,43 @@
+package co.smartreceipts.android.tooltip.image.data
+
+import android.content.SharedPreferences
+import co.smartreceipts.android.di.scopes.ApplicationScope
+import co.smartreceipts.android.utils.rx.RxSchedulers
+import dagger.Lazy
+import io.reactivex.Scheduler
+import io.reactivex.Single
+import javax.inject.Inject
+import javax.inject.Named
+
+@ApplicationScope
+class ImageCroppingPreferenceStorage @Inject constructor(
+    private val preferences: Lazy<SharedPreferences>,
+    @Named(RxSchedulers.IO) private val scheduler: Scheduler
+) : ImageCroppingTooltipStorage {
+
+    companion object {
+        private const val PREFERENCE_CROPPING_SCREEN_WAS_SHOWN = "Cropping screen was shown"
+        private const val PREFERENCE_CROPPING_TOOLTIP_WAS_HANDLED = "Cropping tooltip was handled"
+    }
+
+    override fun getCroppingScreenWasShown(): Single<Boolean> =
+        Single.fromCallable{preferences.get().getBoolean(PREFERENCE_CROPPING_SCREEN_WAS_SHOWN, false)}
+            .subscribeOn(scheduler)
+
+    override fun getCroppingTooltipWasHandled(): Single<Boolean> =
+        Single.fromCallable{preferences.get().getBoolean(PREFERENCE_CROPPING_TOOLTIP_WAS_HANDLED, false)}
+            .subscribeOn(scheduler)
+
+    override fun setCroppingScreenWasShown(value: Boolean) {
+        preferences.get().edit()
+            .putBoolean(PREFERENCE_CROPPING_SCREEN_WAS_SHOWN, value)
+            .apply()
+    }
+
+    override fun setCroppingTooltipWasHandled(value: Boolean) {
+        preferences.get().edit()
+            .putBoolean(PREFERENCE_CROPPING_TOOLTIP_WAS_HANDLED, value)
+            .apply()
+    }
+
+}

--- a/app/src/main/java/co/smartreceipts/android/tooltip/image/data/ImageCroppingTooltipStorage.kt
+++ b/app/src/main/java/co/smartreceipts/android/tooltip/image/data/ImageCroppingTooltipStorage.kt
@@ -1,0 +1,14 @@
+package co.smartreceipts.android.tooltip.image.data
+
+import io.reactivex.Single
+
+interface ImageCroppingTooltipStorage {
+
+    fun getCroppingScreenWasShown(): Single<Boolean>
+
+    fun getCroppingTooltipWasHandled(): Single<Boolean>
+
+    fun setCroppingScreenWasShown(value: Boolean)
+
+    fun setCroppingTooltipWasHandled(value: Boolean)
+}

--- a/app/src/main/java/co/smartreceipts/android/tooltip/model/TooltipType.kt
+++ b/app/src/main/java/co/smartreceipts/android/tooltip/model/TooltipType.kt
@@ -21,6 +21,7 @@ enum class TooltipType(val displayStyle: TooltipDisplayStyle,
     FirstReceiptUsePaymentMethodsQuestion(TooltipDisplayStyle.Question, 69, false, false, false, false),
     RateThisApp(TooltipDisplayStyle.Question, 50, false, false, false, false),
     PrivacyPolicy(TooltipDisplayStyle.Informational, 10, false, true, false, false),
-    OcrInformation(TooltipDisplayStyle.Informational, 5, false, true, false, false)
+    OcrInformation(TooltipDisplayStyle.Informational, 5, false, true, false, false),
+    ImageCropping(TooltipDisplayStyle.Question, 101, false, false, false, true)
 
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -197,7 +197,6 @@
     <string name="toast_reorder_hint">Lange drücken, um das Ziehen zu starten</string>
     <string name="toast_csv_report_distances">Um einen CSV-Bericht zu erstellen, aktivieren Sie die Option %s</string>
     <string name="toast_attachment_error">Diese Datei kann nicht angehängt werden.</string>
-    <string name="toast_disable_crop_option">Sie können die Option zum Zuschneiden von Bildern in den App-Einstellungen deaktivieren</string>
 
     <!-- ================== Trip Adapter ===================== -->
     <string name="trip_adapter_list_item_to">%1$s bis %2$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -197,7 +197,6 @@
     <string name="toast_reorder_hint">Mantenga pulsado el elemento para iniciar el arrastre</string>
     <string name="toast_csv_report_distances">Para crear un informe CSV, compruebe la opción %s</string>
     <string name="toast_attachment_error">No se puede adjuntar este archivo.</string>
-    <string name="toast_disable_crop_option">Puede desactivar la opción de imagen de recorte en la configuración de la aplicación</string>
 
     <!-- ================== Trip Adapter ===================== -->
     <string name="trip_adapter_list_item_to">%1$s hasta %2$s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -197,7 +197,6 @@
     <string name="toast_reorder_hint">Appui long sur l\'élément pour lancer le glisser</string>
     <string name="toast_csv_report_distances">Pour créer un rapport CSV, veuillez cocher l\'option %s</string>
     <string name="toast_attachment_error">Impossible de joindre ce fichier.</string>
-    <string name="toast_disable_crop_option">Vous pouvez désactiver l\'option de rognage d\'image dans les paramètres de l\'application</string>
 
     <!-- ================== Trip Adapter ===================== -->
     <string name="trip_adapter_list_item_to">%1$s à %2$s</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -200,7 +200,6 @@
     <string name="toast_reorder_hint"><![CDATA[לחץ לחיצה ארוכה על הפריט על מנת להתחיל גרירה]]></string>
     <string name="toast_csv_report_distances">%s :על מנת ליצור דוח אקסל אנא לחץ על</string>
     <string name="toast_attachment_error">Unable to attach this file.</string>
-    <string name="toast_disable_crop_option">ניתן להשבית אפשרות חיתוך תמונה בהגדרות האפליקציה</string>
 
     <!-- ================== Trip Adapter ===================== -->
     <string name="trip_adapter_list_item_to">%2$s %1$s אל</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -197,7 +197,6 @@
     <string name="toast_reorder_hint">Pressione prolongadamente o item para iniciar o arrastar</string>
     <string name="toast_csv_report_distances">Para criar um relatório CSV, marque a opção %s</string>
     <string name="toast_attachment_error">Não é possível anexar este arquivo.</string>
-    <string name="toast_disable_crop_option">Você pode desativar a opção de imagem de recorte nas configurações do aplicativo</string>
 
     <!-- ================== Trip Adapter ===================== -->
     <string name="trip_adapter_list_item_to">%1$s para %2$s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -199,7 +199,6 @@
     <string name="toast_reorder_hint">Удерживайте элемент чтобы начать перетаскивание</string>
     <string name="toast_csv_report_distances">Чтобы создать отчет CSV, выберите опцию %s</string>
     <string name="toast_attachment_error">Не удалось прикрепить этот файл.</string>
-    <string name="toast_disable_crop_option">Вы можете отключить функцию обрезки изображения в настройках приложения</string>
 
     <!-- ================== Trip Adapter ===================== -->
     <string name="trip_adapter_list_item_to">%1$s до %2$s</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -199,7 +199,6 @@
     <string name="toast_reorder_hint">Утримуйте елемент, щоб почати перетягування</string>
     <string name="toast_csv_report_distances">Щоб створити звіт у форматі CSV, будь ласка, поставте галочку %s</string>
     <string name="toast_attachment_error">Не вдається прикріпити цей файл.</string>
-    <string name="toast_disable_crop_option">Ви можете відключити опцію кадрування зображення в налаштуваннях програми</string>
 
     <!-- ================== Trip Adapter ===================== -->
     <string name="trip_adapter_list_item_to">%1$s до %2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,7 +198,6 @@
     <string name="toast_reorder_hint"><![CDATA[Long press item to initiate dragging]]></string>
     <string name="toast_csv_report_distances">To create CSV report please check option %s</string>
     <string name="toast_attachment_error">Unable to attach this file.</string>
-    <string name="toast_disable_crop_option">You can disable crop image option in the app settings</string>
 
     <!-- ================== Trip Adapter ===================== -->
     <string name="trip_adapter_list_item_to">%1$s to %2$s</string>

--- a/app/src/test/java/co/smartreceipts/android/tooltip/TooltipControllerProviderTest.kt
+++ b/app/src/test/java/co/smartreceipts/android/tooltip/TooltipControllerProviderTest.kt
@@ -2,15 +2,15 @@ package co.smartreceipts.android.tooltip
 
 import co.smartreceipts.android.ocr.widget.tooltip.OcrInformationTooltipController
 import co.smartreceipts.android.tooltip.backup.AutomaticBackupRecoveryHintUserController
+import co.smartreceipts.android.tooltip.image.ImageCroppingTooltipController
 import co.smartreceipts.android.tooltip.model.TooltipType
 import co.smartreceipts.android.tooltip.privacy.PrivacyPolicyTooltipController
 import co.smartreceipts.android.tooltip.rating.RateThisAppTooltipController
 import co.smartreceipts.android.tooltip.receipt.paymentmethods.FirstReceiptUsePaymentMethodsQuestionTooltipController
 import co.smartreceipts.android.tooltip.receipt.taxes.FirstReceiptUseTaxesQuestionTooltipController
 import co.smartreceipts.android.tooltip.report.FirstReportHintTooltipController
+import org.junit.Assert.assertTrue
 import org.junit.Before
-
-import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
@@ -44,16 +44,20 @@ class TooltipControllerProviderTest {
     @Mock
     private lateinit var firstReceiptUsePaymentMethodsQuestionTooltipProvider: FirstReceiptUsePaymentMethodsQuestionTooltipController
 
+    @Mock
+    private lateinit var croppingTooltipController: ImageCroppingTooltipController
+
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
         tooltipControllerProvider = TooltipControllerProvider(Provider { return@Provider automaticBackupRecoveryHintUserController },
-                                                              Provider { return@Provider firstReportHintTooltipController },
-                                                              Provider { return@Provider privacyPolicyTooltipController },
-                                                              Provider { return@Provider rateThisAppTooltipController },
-                                                              Provider { return@Provider ocrInformationTooltipController },
-                                                              Provider { return@Provider firstReceiptUseTaxesQuestionTooltipController },
-                                                              Provider { return@Provider firstReceiptUsePaymentMethodsQuestionTooltipProvider })
+            Provider { return@Provider firstReportHintTooltipController },
+            Provider { return@Provider privacyPolicyTooltipController },
+            Provider { return@Provider rateThisAppTooltipController },
+            Provider { return@Provider ocrInformationTooltipController },
+            Provider { return@Provider firstReceiptUseTaxesQuestionTooltipController },
+            Provider { return@Provider firstReceiptUsePaymentMethodsQuestionTooltipProvider },
+            Provider { return@Provider croppingTooltipController })
     }
 
     @Test
@@ -89,6 +93,11 @@ class TooltipControllerProviderTest {
     @Test
     fun getFirstReceiptUsePaymentMethodsQuestionTooltipController() {
         assertTrue(tooltipControllerProvider.get(TooltipType.FirstReceiptUsePaymentMethodsQuestion) is FirstReceiptUsePaymentMethodsQuestionTooltipController)
+    }
+
+    @Test
+    fun getImageCroppingTooltipController() {
+        assertTrue(tooltipControllerProvider.get(TooltipType.ImageCropping) is ImageCroppingTooltipController)
     }
 
 }

--- a/app/src/test/java/co/smartreceipts/android/tooltip/image/ImageCroppingTooltipControllerTest.kt
+++ b/app/src/test/java/co/smartreceipts/android/tooltip/image/ImageCroppingTooltipControllerTest.kt
@@ -1,0 +1,121 @@
+package co.smartreceipts.android.tooltip.image
+
+import co.smartreceipts.android.R
+import co.smartreceipts.android.settings.UserPreferenceManager
+import co.smartreceipts.android.settings.catalog.UserPreference
+import co.smartreceipts.android.tooltip.TooltipView
+import co.smartreceipts.android.tooltip.image.data.ImageCroppingPreferenceStorage
+import co.smartreceipts.android.tooltip.model.TooltipInteraction
+import co.smartreceipts.android.tooltip.model.TooltipMetadata
+import co.smartreceipts.android.tooltip.model.TooltipType
+import com.hadisatrio.optional.Optional
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.verifyZeroInteractions
+import com.nhaarman.mockito_kotlin.whenever
+import io.reactivex.Single
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class ImageCroppingTooltipControllerTest {
+
+    lateinit var controller: ImageCroppingTooltipController
+
+    @Mock
+    lateinit var tooltipView: TooltipView
+
+    @Mock
+    lateinit var prefStorage: ImageCroppingPreferenceStorage
+
+    @Mock
+    lateinit var prefManager: UserPreferenceManager
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+
+        controller = ImageCroppingTooltipController(RuntimeEnvironment.application, tooltipView, prefStorage, prefManager)
+    }
+
+    @Test
+    fun doNotDisplayTooltipIfCroppingWasNotShown() {
+        whenever(prefStorage.getCroppingScreenWasShown()).thenReturn(Single.just(false))
+        whenever(prefStorage.getCroppingTooltipWasHandled()).thenReturn(Single.just(false))
+
+        controller.shouldDisplayTooltip().test()
+            .assertComplete()
+            .assertNoErrors()
+            .assertValue(Optional.absent())
+    }
+
+    @Test
+    fun doNotDisplayTooltipIfItWasAlreadyShown() {
+        whenever(prefStorage.getCroppingScreenWasShown()).thenReturn(Single.just(true))
+        whenever(prefStorage.getCroppingTooltipWasHandled()).thenReturn(Single.just(true))
+
+        controller.shouldDisplayTooltip().test()
+            .assertComplete()
+            .assertNoErrors()
+            .assertValue(Optional.absent())
+    }
+
+    @Test
+    fun displayTooltip() {
+        whenever(prefStorage.getCroppingScreenWasShown()).thenReturn(Single.just(true))
+        whenever(prefStorage.getCroppingTooltipWasHandled()).thenReturn(Single.just(false))
+
+        controller.shouldDisplayTooltip().test()
+            .assertComplete()
+            .assertNoErrors()
+            .assertResult(Optional.of(TooltipMetadata(TooltipType.ImageCropping,  RuntimeEnvironment.application.getString(R.string.pref_general_enable_crop_title))))
+    }
+
+    @Test
+    fun handleYesTooltipClick() {
+        val interaction = TooltipInteraction.YesButtonClick
+
+        controller.handleTooltipInteraction(interaction).test()
+            .await()
+            .assertComplete()
+            .assertNoErrors()
+
+        verify(prefManager).set(UserPreference.General.EnableCrop, true)
+        verify(prefStorage).setCroppingTooltipWasHandled(true)
+    }
+
+    @Test
+    fun handleNoTooltipClick() {
+        val interaction = TooltipInteraction.NoButtonClick
+
+        controller.handleTooltipInteraction(interaction).test()
+            .await()
+            .assertComplete()
+            .assertNoErrors()
+
+        verify(prefManager).set(UserPreference.General.EnableCrop, false)
+        verify(prefStorage).setCroppingTooltipWasHandled(true)
+    }
+
+    @Test
+    fun consumeTooltipYes() {
+        controller.consumeTooltipInteraction().accept(TooltipInteraction.YesButtonClick)
+
+        verify(tooltipView).hideTooltip()
+        verifyZeroInteractions(prefManager, prefStorage)
+    }
+
+    @Test
+    fun consumeTooltipNo() {
+        controller.consumeTooltipInteraction().accept(TooltipInteraction.NoButtonClick)
+
+        verify(tooltipView).hideTooltip()
+        verifyZeroInteractions(prefManager, prefStorage)
+    }
+
+
+}


### PR DESCRIPTION
Added new "Enable Crop Image Screen" question `tooltip` with Yes|No buttons. It appears on the `ReceiptCreateEditFragment` in a case when a user has already interacted with cropping screen but he didn't handle this tooltip yet.