### PR TITLE
Editing receipt shows auto complete

### DIFF
--- a/app/src/main/java/co/smartreceipts/android/autocomplete/AutoCompleteInteractor.kt
+++ b/app/src/main/java/co/smartreceipts/android/autocomplete/AutoCompleteInteractor.kt
@@ -40,7 +40,7 @@ class AutoCompleteInteractor<Type> constructor(private val provider: AutoComplet
         // Confirm that the user has this setting enable
         if (userPreferenceManager[UserPreference.Receipts.EnableAutoCompleteSuggestions]) {
             // And that we've typed this exact amount of characters (as the adapters manage filtering afterwards)
-            if (input.length == TEXT_LENGTH_TO_FETCH_RESULTS) {
+            if (input.length >= TEXT_LENGTH_TO_FETCH_RESULTS) {
                 return provider.tableController.get()
                         .subscribeOn(backgroundScheduler)
                         .flatMapMaybe { getResults ->

--- a/app/src/main/java/co/smartreceipts/android/autocomplete/AutoCompletePresenter.kt
+++ b/app/src/main/java/co/smartreceipts/android/autocomplete/AutoCompletePresenter.kt
@@ -1,7 +1,6 @@
 package co.smartreceipts.android.autocomplete
 
 import co.smartreceipts.core.di.scopes.FragmentScope
-import co.smartreceipts.android.editor.Editor
 import co.smartreceipts.android.widget.mvp.BasePresenter
 import io.reactivex.Scheduler
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -12,27 +11,23 @@ import javax.inject.Inject
  */
 @FragmentScope
 class AutoCompletePresenter<Type>(view: AutoCompleteView<Type>,
-                                  private val editor: Editor<Type>,
                                   private val interactor: AutoCompleteInteractor<Type>,
                                   private val mainThreadScheduler: Scheduler) : BasePresenter<AutoCompleteView<Type>>(view) {
 
     @Inject
     constructor(view: AutoCompleteView<Type>,
-                editor: Editor<Type>,
-                interactor: AutoCompleteInteractor<Type>) : this(view, editor, interactor, AndroidSchedulers.mainThread())
+                interactor: AutoCompleteInteractor<Type>) : this(view, interactor, AndroidSchedulers.mainThread())
 
     override fun subscribe() {
-        if (editor.editableItem == null) {
-            interactor.supportedAutoCompleteFields.forEach { autoCompleteField ->
-                compositeDisposable.add(view.getTextChangeStream(autoCompleteField)
-                        .flatMapMaybe { inputText ->
-                            interactor.getAutoCompleteResults(autoCompleteField, inputText)
-                        }
-                        .observeOn(mainThreadScheduler)
-                        .subscribe{
-                            view.displayAutoCompleteResults(autoCompleteField, it)
-                        })
-            }
+        interactor.supportedAutoCompleteFields.forEach { autoCompleteField ->
+            compositeDisposable.add(view.getTextChangeStream(autoCompleteField)
+                    .flatMapMaybe { inputText ->
+                        interactor.getAutoCompleteResults(autoCompleteField, inputText)
+                    }
+                    .observeOn(mainThreadScheduler)
+                    .subscribe{
+                        view.displayAutoCompleteResults(autoCompleteField, it)
+                    })
         }
     }
 

--- a/app/src/test/java/co/smartreceipts/android/autocomplete/AutoCompleteInteractorTest.kt
+++ b/app/src/test/java/co/smartreceipts/android/autocomplete/AutoCompleteInteractorTest.kt
@@ -79,9 +79,12 @@ class AutoCompleteInteractorTest {
 
     @Test
     fun getAutoCompleteResultsWhenMultipleCharactersAreTyped() {
-        interactor.getAutoCompleteResults(autoCompleteField, "Test")
+        whenever(resultsChecker.getValue(autoCompleteField, matchingResult1)).thenReturn("Test")
+        whenever(resultsChecker.getValue(autoCompleteField, matchingResult2)).thenReturn("Test2")
+        whenever(resultsChecker.getValue(autoCompleteField, nonMatchingResult)).thenReturn("Non-Test")
+        interactor.getAutoCompleteResults(autoCompleteField, "Te")
                 .test()
-                .assertNoValues()
+                .assertValues(listOf(AutoCompleteResult("Test", matchingResult1), AutoCompleteResult("Test2", matchingResult2)))
                 .assertNoErrors()
                 .assertComplete()
     }

--- a/app/src/test/java/co/smartreceipts/android/autocomplete/AutoCompletePresenterTest.kt
+++ b/app/src/test/java/co/smartreceipts/android/autocomplete/AutoCompletePresenterTest.kt
@@ -51,7 +51,7 @@ class AutoCompletePresenterTest {
         whenever(view.getTextChangeStream(field2)).thenReturn(field2TextChanges)
         whenever(interactor.getAutoCompleteResults(eq(field1), any())).thenReturn(Maybe.just(FIELD_1_RESULTS))
         whenever(interactor.getAutoCompleteResults(eq(field2), any())).thenReturn(Maybe.just(FIELD_2_RESULTS))
-        presenter = AutoCompletePresenter(view, editor, interactor, Schedulers.trampoline())
+        presenter = AutoCompletePresenter(view, interactor, Schedulers.trampoline())
     }
 
     @Test

--- a/app/src/test/java/co/smartreceipts/android/autocomplete/AutoCompletePresenterTest.kt
+++ b/app/src/test/java/co/smartreceipts/android/autocomplete/AutoCompletePresenterTest.kt
@@ -58,8 +58,10 @@ class AutoCompletePresenterTest {
     fun subscribeWhenEditing() {
         whenever(editor.editableItem).thenReturn(Any())
         presenter.subscribe()
-        verify(view, never()).displayAutoCompleteResults(any(), any())
-        verifyZeroInteractions(interactor)
+        field1TextChanges.onNext("1")
+        verify(view).displayAutoCompleteResults(field1, FIELD_1_RESULTS)
+        field2TextChanges.onNext("2")
+        verify(view).displayAutoCompleteResults(field2, FIELD_2_RESULTS)
     }
 
     @Test


### PR DESCRIPTION
These changes apply to all editable fields (comment, location, and name inside trip, receipt, and distance). Is that okay?